### PR TITLE
Seorak fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+
+*.pyc
+.cache/v/cache/lastfailed

--- a/romanizer.py
+++ b/romanizer.py
@@ -200,7 +200,7 @@ class Pronouncer(object):
                 final_is_before_C = False
                 
             try:    
-                final_is_before_V = syllable.final and next_syllable.initial is None
+                final_is_before_V = syllable.final and next_syllable.initial in (None, NULL_CONSONANT)
             except AttributeError:
                 final_is_before_V = False 
             
@@ -261,7 +261,7 @@ class Pronouncer(object):
                         syllable.final = None
             # 5. 홑받침이나 쌍받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는, 
             # 제 음가대로 뒤 음절 첫소리로 옮겨 발음한다. 
-            if next_syllable and final_is_before_C:
+            if next_syllable and final_is_before_V:
                 if(next_syllable.initial == NULL_CONSONANT):
                     next_syllable.initial = next_syllable.final_to_initial(syllable.final)
                     syllable.final = None

--- a/romanizer.py
+++ b/romanizer.py
@@ -195,7 +195,7 @@ class Pronouncer(object):
                 next_syllable = None
                 
             try:    
-                final_is_before_C = syllable.final and next_syllable.getattr(initial) not in (None, NULL_CONSONANT)
+                final_is_before_C = syllable.final and next_syllable.initial not in (None, NULL_CONSONANT)
             except AttributeError:
                 final_is_before_C = False
                 


### PR DESCRIPTION
For pronunciation, a coda consonant should take the place of the null consonant in the onset position of the next syllable. The test passes for 설악 with no regressions.