### PR TITLE
Fix - key error for a special case such as "뚫리다" 

### DIFF
--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -1,27 +1,27 @@
 from korean_romanizer.syllable import Syllable
 
 double_consonant_final = {
-    'ᆪ' : ('ᆨ', 'ᆺ'),
-    'ᆬ' : ('ᆫ', 'ᆽ'),
-    'ᆭ' : ('ᆫ', 'ᇂ'),
-    'ᆰ' : ('ᆯ', 'ᆨ'),
-    'ᆱ' : ('ᆯ', 'ᆷ'),
-    'ᆲ' : ('ᆯ', 'ᆸ'),
-    'ᆳ' : ('ᆯ', 'ᆻ'),
-    'ᆴ' : ('ᆯ', 'ᇀ'),
-    'ᆵ' : ('ᆯ', 'ᇁ'),
-    'ㅀ' : ('ㄹ', 'ᇂ'),
-    'ᆹ' : ('ᆸ', 'ᆺ'),
-    'ㅆ' : ('ㅅ', 'ㅅ')
+    'ᆪ': ('ᆨ', 'ᆺ'),
+    'ᆬ': ('ᆫ', 'ᆽ'),
+    'ᆭ': ('ᆫ', 'ᇂ'),
+    'ᆰ': ('ᆯ', 'ᆨ'),
+    'ᆱ': ('ᆯ', 'ᆷ'),
+    'ᆲ': ('ᆯ', 'ᆸ'),
+    'ᆳ': ('ᆯ', 'ᆻ'),
+    'ᆴ': ('ᆯ', 'ᇀ'),
+    'ᆵ': ('ᆯ', 'ᇁ'),
+    'ᆶ': ('ᆯ', 'ᇂ'),
+    'ᆹ': ('ᆸ', 'ᆺ'),
+    'ㅆ': ('ㅅ', 'ㅅ')
 }
 
 NULL_CONSONANT = 'ᄋ'
 
+
 class Pronouncer(object):
     def __init__(self, text):
         self._syllables = [Syllable(char) for char in text]
-        self.pronounced = ''.join([ str(c) for c in self.final_substitute()])
-
+        self.pronounced = ''.join([str(c) for c in self.final_substitute()])
 
     def final_substitute(self):
         for idx, syllable in enumerate(self._syllables):
@@ -31,12 +31,14 @@ class Pronouncer(object):
                 next_syllable = None
 
             try:
-                final_is_before_C = syllable.final and next_syllable.initial not in (None, NULL_CONSONANT)
+                final_is_before_C = syllable.final and next_syllable.initial not in (
+                    None, NULL_CONSONANT)
             except AttributeError:
                 final_is_before_C = False
 
             try:
-                final_is_before_V = syllable.final and next_syllable.initial in (None, NULL_CONSONANT)
+                final_is_before_V = syllable.final and next_syllable.initial in (
+                    None, NULL_CONSONANT)
             except AttributeError:
                 final_is_before_V = False
 
@@ -47,70 +49,75 @@ class Pronouncer(object):
             # 3. 겹받침 ‘ㄺ, ㄻ, ㄿ’은 어말 또는 자음 앞에서 각각 [ㄱ, ㅁ, ㅂ]으로 발음한다.
             # <-> 단, 국어의 로마자 표기법 규정에 의해 된소리되기는 표기에 반영하지 않으므로 제외.
             if is_last_syllable or final_is_before_C:
-                if(syllable.final in ['ᆩ', 'ᆿ', 'ᆪ', 'ᆰ']):
+                if (syllable.final in ['ᆩ', 'ᆿ', 'ᆪ', 'ᆰ']):
                     syllable.final = 'ᆨ'
-                elif(syllable.final in ['ᆺ', 'ᆻ', 'ᆽ', 'ᆾ', 'ᇀ']):
+                elif (syllable.final in ['ᆺ', 'ᆻ', 'ᆽ', 'ᆾ', 'ᇀ']):
                     syllable.final = 'ᆮ'
-                elif(syllable.final in ['ᇁ', 'ᆹ', 'ᆵ']):
+                elif (syllable.final in ['ᇁ', 'ᆹ', 'ᆵ']):
                     syllable.final = 'ᆸ'
-                elif(syllable.final in ['ᆬ']):
+                elif (syllable.final in ['ᆬ']):
                     syllable.final = 'ᆫ'
-                elif(syllable.final in ['ᆲ', 'ᆳ', 'ᆴ']):
+                elif (syllable.final in ['ᆲ', 'ᆳ', 'ᆴ']):
                     syllable.final = 'ᆯ'
-                elif(syllable.final in ['ᆱ']):
+                elif (syllable.final in ['ᆱ']):
                     syllable.final = 'ᆷ'
-            
+
             # 4. 받침 ‘ㅎ’의 발음은 다음과 같다.
             if syllable.final in ['ᇂ', 'ᆭ', 'ᆶ']:
                 without_ㅎ = {
-                    'ᆭ' : 'ᆫ',
-                    'ᆶ' : 'ᆯ',
-                    'ᇂ' : None
+                    'ᆭ': 'ᆫ',
+                    'ᆶ': 'ᆯ',
+                    'ᇂ': None
                 }
 
                 if next_syllable:
                     # ‘ㅎ(ㄶ, ㅀ)’ 뒤에 ‘ㄱ, ㄷ, ㅈ’이 결합되는 경우에는, 뒤 음절 첫소리와 합쳐서 [ㅋ, ㅌ, ㅊ]으로 발음한다.
                     # ‘ㅎ(ㄶ, ㅀ)’ 뒤에 ‘ㅅ’이 결합되는 경우에는, ‘ㅅ’을 [ㅆ]으로 발음한다.
                     if next_syllable.initial in ['ᄀ', 'ᄃ', 'ᄌ', 'ᄉ']:
-                        change_to = {'ᄀ': 'ᄏ','ᄃ': 'ᄐ','ᄌ':'ᄎ', 'ᄉ': 'ᄊ'}
+                        change_to = {'ᄀ': 'ᄏ', 'ᄃ': 'ᄐ', 'ᄌ': 'ᄎ', 'ᄉ': 'ᄊ'}
                         syllable.final = without_ㅎ[syllable.final]
                         next_syllable.initial = change_to[next_syllable.initial]
                     # 3. ‘ㅎ’ 뒤에 ‘ㄴ’이 결합되는 경우에는, [ㄴ]으로 발음한다.
                     elif next_syllable.initial in ['ᄂ']:
                         # TODO: [붙임] ‘ㄶ, ㅀ’ 뒤에 ‘ㄴ’이 결합되는 경우에는, ‘ㅎ’을 발음하지 않는다.
-                        if(syllable.final in ['ᆭ', 'ᆶ']):
+                        if (syllable.final in ['ᆭ', 'ᆶ']):
                             syllable.final = without_ㅎ[syllable.final]
                         else:
                             syllable.final = 'ᆫ'
-                    #4. ‘ㅎ(ㄶ, ㅀ)’ 뒤에 모음으로 시작된 어미나 접미사가 결합되는 경우에는,
+                    # 4. ‘ㅎ(ㄶ, ㅀ)’ 뒤에 모음으로 시작된 어미나 접미사가 결합되는 경우에는,
                     # ‘ㅎ’을 발음하지 않는다.
                     elif next_syllable.initial == NULL_CONSONANT:
-                        if(syllable.final in ['ᆭ', 'ᆶ']):
+                        if (syllable.final in ['ᆭ', 'ᆶ']):
                             if syllable.final == 'ᆭ':
                                 syllable.final = 'ᆫ'
                             elif syllable.final == 'ᆶ':
                                 syllable.final = 'ᆯ'
                         else:
                             syllable.final = None
+                    elif next_syllable.initial == 'ᄅ':
+                        if (syllable.final == 'ᆶ'):
+                            syllable.final = 'ᆯ'
                     else:
                         if (syllable.final == 'ᇂ'):
                             syllable.final = None
                 else:
                     if (syllable.final == 'ᇂ'):
                         syllable.final = None
-
             # 6. 겹받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
             # 뒤엣것만을 뒤 음절 첫소리로 옮겨 발음한다.(이 경우, ‘ㅅ’은 된소리로 발음함.)
             if syllable.final in double_consonant_final and next_syllable.initial == NULL_CONSONANT:
+
                 double_consonant = double_consonant_final[syllable.final]
                 syllable.final = double_consonant[0]
-                next_syllable.initial = next_syllable.final_to_initial(double_consonant[1])
-
+                next_syllable.initial = next_syllable.final_to_initial(
+                    double_consonant[1])
             # 5. 홑받침이나 쌍받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
             # 제 음가대로 뒤 음절 첫소리로 옮겨 발음한다.
             if next_syllable and final_is_before_V:
-                if(next_syllable.initial == NULL_CONSONANT and syllable.final not in ["ᆼ", None]): # do nothing if final is ᆼ or null
-                    next_syllable.initial = next_syllable.final_to_initial(syllable.final)
+                # do nothing if final is ᆼ or null
+                if (next_syllable.initial == NULL_CONSONANT and syllable.final not in ["ᆼ", None]):
+                    next_syllable.initial = next_syllable.final_to_initial(
+                        syllable.final)
                     syllable.final = None
-                                    
+
         return self._syllables

--- a/setup.py
+++ b/setup.py
@@ -2,13 +2,13 @@ from distutils.core import setup
 setup(
   name = 'korean_romanizer',
   packages = ['korean_romanizer'],
-  version = '0.23',
+  version = '0.24',
   license='GNU GPLv3',
   description = 'A Python library for Korean romanization',
   author = 'Ilkyu Ju',
   author_email = 'ju.ilkyu@gmail.com',
   url = 'https://github.com/osori/korean-romanizer',
-  download_url = 'https://github.com/osori/korean-romanizer/archive/0.23.tar.gz',
+  download_url = 'https://github.com/osori/korean-romanizer/archive/0.24.tar.gz',
   keywords = ['Korean', 'Romanization', 'Transliteration'],
   classifiers=[
     'Development Status :: 3 - Alpha',

--- a/tests/test_romanizer.py
+++ b/tests/test_romanizer.py
@@ -1,20 +1,25 @@
 import pytest
 from korean_romanizer.romanizer import Romanizer
 
+
 def romanize(text):
     r = Romanizer(text)
     return r.romanize()
 
+
 def test_simple():
     assert romanize("안녕하세요") == "annyeonghaseyo"
 
+
 def test_spaced_text():
     assert romanize("아이유 방탄소년단") == "aiyu bangtansonyeondan"
+
 
 def test_onset_g_d_b():
     assert romanize("구미") == "gumi"
     assert romanize("영동") == "yeongdong"
     assert romanize("한밭") == "hanbat"
+
 
 def test_coda_g_d_b():
     assert romanize("밝다") == "bakda"
@@ -23,17 +28,20 @@ def test_coda_g_d_b():
     assert romanize("앞만") == "apman"
     assert romanize("읊다") == "eupda"
 
+
 def test_r_l():
     assert romanize("구리") == "guri"
     assert romanize("설악") == "seorak"
 #    assert romanize("울릉") == "ulleung"
 #    assert romanize("대관령") == "daegwallyeong"
 
+
 def test_next_syllable_null_initial():
     assert romanize("강약") == "gangyak"
     assert romanize("강원") == "gangwon"
     assert romanize("좋아하고") == "joahago"
     assert romanize("좋은") == "joeun"
+
 
 def test_double_consonant_final_and_next_syllable_null_initial():
     assert romanize("했었어요") == "haesseosseoyo"
@@ -48,9 +56,17 @@ def test_double_consonant_final_and_next_syllable_null_initial():
     assert romanize("곬이") == "golssi"
     assert romanize("훑어보다") == "hulteoboda"
 
+
+def test_double_consonant_final_and_next_syllable_not_null_initial():
+    assert romanize("앉고싶다") == "angosipda"
+    assert romanize("뚫리다") == "ttulrida"
+    assert romanize("칡뿌리") == "chikppuri"
+
+
 def test_non_syllables():
     assert romanize("ㅠㄴㅁㄱ") == "ㅠㄴㅁㄱ"
     assert romanize("ㅠ동") == "ㅠdong"
+
 
 def test_coda_h():
     assert romanize("않습니다") == "ansseupnida"


### PR DESCRIPTION
# Summary

Apparently, while I was working on my personal project, I need a simple romanization library for Korean language. And, I found this library. However, I encountered one edge case and this library does not support.

For instance, if a word has a double constant which is "ㅀ" and the next syllable starts with `NULL_CONSONANT`. It will throw a Key-error as #15 described. It is because there is no logic to handle such case in `pronouncer.py'

So, I created a logic to handle such cases.

# Changes
1. Added a logic to handle a special case a syllable has "ㅀ" and the next syllable starts with `NULL_CONSONANT`
2. Added `test_double_consonant_final_and_next_syllable_not_null_initial` in `test_romanizer.py` to prevent this situation in the future.
3. Applied prettier for some files.

# Screenshots

## Pytest Result
![image](https://user-images.githubusercontent.com/13793276/209574718-1d8bc604-99f6-476c-b6f9-6e9551cadaee.png)
