### PR TITLE
Add case for handling double consonant finals without next syllable

### DIFF
--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -105,12 +105,15 @@ class Pronouncer(object):
                         syllable.final = None
             # 6. 겹받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
             # 뒤엣것만을 뒤 음절 첫소리로 옮겨 발음한다.(이 경우, ‘ㅅ’은 된소리로 발음함.)
-            if syllable.final in double_consonant_final and next_syllable and next_syllable.initial == NULL_CONSONANT:
-
-                double_consonant = double_consonant_final[syllable.final]
-                syllable.final = double_consonant[0]
-                next_syllable.initial = next_syllable.final_to_initial(
-                    double_consonant[1])
+            if syllable.final in double_consonant_final:
+                if not next_syllable:
+                    syllable.final = double_consonant_final[syllable.final][0]
+                elif next_syllable.initial == NULL_CONSONANT:
+                    double_consonant = double_consonant_final[syllable.final]
+                    syllable.final = double_consonant[0]
+                    next_syllable.initial = next_syllable.final_to_initial(
+                        double_consonant[1])
+                    
             # 5. 홑받침이나 쌍받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
             # 제 음가대로 뒤 음절 첫소리로 옮겨 발음한다.
             if next_syllable and final_is_before_V:
@@ -119,8 +122,5 @@ class Pronouncer(object):
                     next_syllable.initial = next_syllable.final_to_initial(
                         syllable.final)
                     syllable.final = None
-                    
-            if not next_syllable and syllable.final in double_consonant_final:
-                syllable.final = double_consonant_final[syllable.final][0]
 
         return self._syllables

--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -101,18 +101,15 @@ class Pronouncer(object):
                         if (syllable.final == 'ᇂ'):
                             syllable.final = None
                 else:
-                    if (syllable.final == 'ᇂ'):
-                        syllable.final = None
+                    syllable.final = without_ㅎ[syllable.final]
+                        
             # 6. 겹받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
             # 뒤엣것만을 뒤 음절 첫소리로 옮겨 발음한다.(이 경우, ‘ㅅ’은 된소리로 발음함.)
-            if syllable.final in double_consonant_final:
-                if not next_syllable:
-                    syllable.final = double_consonant_final[syllable.final][0]
-                elif next_syllable.initial == NULL_CONSONANT:
-                    double_consonant = double_consonant_final[syllable.final]
-                    syllable.final = double_consonant[0]
-                    next_syllable.initial = next_syllable.final_to_initial(
-                        double_consonant[1])
+            if syllable.final in double_consonant_final and next_syllable.initial == NULL_CONSONANT:
+                double_consonant = double_consonant_final[syllable.final]
+                syllable.final = double_consonant[0]
+                next_syllable.initial = next_syllable.final_to_initial(
+                    double_consonant[1])
                     
             # 5. 홑받침이나 쌍받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
             # 제 음가대로 뒤 음절 첫소리로 옮겨 발음한다.

--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -105,7 +105,7 @@ class Pronouncer(object):
                         syllable.final = None
             # 6. 겹받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
             # 뒤엣것만을 뒤 음절 첫소리로 옮겨 발음한다.(이 경우, ‘ㅅ’은 된소리로 발음함.)
-            if syllable.final in double_consonant_final and next_syllable.initial == NULL_CONSONANT:
+            if syllable.final in double_consonant_final and next_syllable and next_syllable.initial == NULL_CONSONANT:
 
                 double_consonant = double_consonant_final[syllable.final]
                 syllable.final = double_consonant[0]
@@ -119,5 +119,8 @@ class Pronouncer(object):
                     next_syllable.initial = next_syllable.final_to_initial(
                         syllable.final)
                     syllable.final = None
+                    
+            if not next_syllable and syllable.final in double_consonant_final:
+                syllable.final = double_consonant_final[syllable.final][0]
 
         return self._syllables

--- a/tests/test_romanizer.py
+++ b/tests/test_romanizer.py
@@ -64,9 +64,9 @@ def test_double_consonant_final_and_next_syllable_not_null_initial():
     
 
 def test_double_consonant_final_without_next_syllable():
-    assert romanize("괜") == "gwaen"
+    assert romanize("괜찮") == "gwaenchan"
     assert romanize("뚫") == "ttul"
-    assert romanize("앉") == "an"
+    assert romanize("않") == "an"
 
 
 def test_non_syllables():

--- a/tests/test_romanizer.py
+++ b/tests/test_romanizer.py
@@ -61,6 +61,12 @@ def test_double_consonant_final_and_next_syllable_not_null_initial():
     assert romanize("앉고싶다") == "angosipda"
     assert romanize("뚫리다") == "ttulrida"
     assert romanize("칡뿌리") == "chikppuri"
+    
+
+def test_double_consonant_final_without_next_syllable():
+    assert romanize("괜") == "gwaen"
+    assert romanize("뚫") == "ttul"
+    assert romanize("앉") == "an"
 
 
 def test_non_syllables():


### PR DESCRIPTION
There is a case where if a syllable ends with double consonants containing ᇂ (such as 뚫 or 않) and is not followed by another syllable, it would throw an error. I added better handling for such cases and wrote tests for it.