### PR TITLE
Add PyPI publishing workflow

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,8 +9,12 @@
 name: Upload Python Package
 
 on:
+  push:
+    tags:
+      - '*'
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/README.md
+++ b/README.md
@@ -19,3 +19,10 @@ r = Romanizer("안녕하세요")
 r.romanize() 
 # returns 'annyeonghaseyo'
 ```
+
+## Releasing
+
+Publishing to PyPI is automated using GitHub Actions. Pushing a version tag or
+creating a GitHub release triggers the workflow in
+`.github/workflows/python-publish.yml` which builds and uploads the package using
+the `PYPI_API_TOKEN` secret.

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,13 @@ from distutils.core import setup
 setup(
   name = 'korean_romanizer',
   packages = ['korean_romanizer'],
-  version = '0.25',
+  version = '0.26',
   license='GNU GPLv3',
   description = 'A Python library for Korean romanization',
   author = 'Ilkyu Ju',
   author_email = 'ju.ilkyu@gmail.com',
   url = 'https://github.com/osori/korean-romanizer',
-  download_url = 'https://github.com/osori/korean-romanizer/archive/0.25.tar.gz',
+  download_url = 'https://github.com/osori/korean-romanizer/archive/0.26.tar.gz',
   keywords = ['Korean', 'Romanization', 'Transliteration'],
   classifiers=[
     'Development Status :: 3 - Alpha',


### PR DESCRIPTION
## Summary
- trigger package publishing on push tags or release
- document automatic release process in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fa5b6a8508333ab0857a66c2ecad6