### PR TITLE
Derive package version from git tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,4 +25,6 @@ r.romanize()
 Publishing to PyPI is automated using GitHub Actions. Pushing a version tag or
 creating a GitHub release triggers the workflow in
 `.github/workflows/python-publish.yml` which builds and uploads the package using
-the `PYPI_API_TOKEN` secret.
+the `PYPI_API_TOKEN` secret. The package version is derived from git tags using
+`setuptools_scm`, so create a new tag or GitHub release when publishing a new
+version.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=42", "setuptools_scm[toml]>=6.2"]
+build-backend = "setuptools.build_meta"

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,4 @@
 [metadata]
 description-file = README.md
+
+[tool.setuptools_scm]

--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,12 @@ from setuptools import setup
 setup(
   name = 'korean_romanizer',
   packages = ['korean_romanizer'],
-  version = '0.26',
+  use_scm_version=True,
   license='GNU GPLv3',
   description = 'A Python library for Korean romanization',
   author = 'Ilkyu Ju',
   author_email = 'ju.ilkyu@gmail.com',
   url = 'https://github.com/osori/korean-romanizer',
-  download_url = 'https://github.com/osori/korean-romanizer/archive/0.26.tar.gz',
   keywords = ['Korean', 'Romanization', 'Transliteration'],
   classifiers=[
     'Development Status :: 3 - Alpha',


### PR DESCRIPTION
## Summary
- use `setuptools_scm` with a minimal pyproject for SCM-based versions
- configure setuptools_scm in `setup.cfg`
- update `setup.py` to rely on SCM version
- document the versioning change in `README`

## Testing
- `pip install -e .[dev]` *(fails: extra 'dev' not provided but package built successfully)*
- `flake8 .` *(fails with many style errors)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685fafdb27548333ad34439c59062a36