### PR TITLE
Fix release workflow trigger

### DIFF
--- a/.github/workflows/python-publish.yml
+++ b/.github/workflows/python-publish.yml
@@ -9,12 +9,8 @@
 name: Upload Python Package
 
 on:
-  push:
-    tags:
-      - '*'
   release:
     types: [published]
-  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- update `python-publish` workflow to run only on releases
- remove manual dispatch and maintainer check

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fbf9f69588333bbfc2caa16a80b4c