### PR TITLE
Add CLI tests and run them in CI

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,6 +23,7 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
+        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -23,7 +23,6 @@ jobs:
       uses: actions/setup-python@v3
       with:
         python-version: "3.10"
-        cache: 'pip'
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -28,6 +28,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install flake8 pytest
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+        pip install .
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,29 +8,63 @@ import pytest
 from korean_romanizer.romanizer import Romanizer
 
 
-def _run_cli(args):
-    env = {**os.environ, "PYTHONIOENCODING": "UTF-8"}
+UTF8_ENV = {**os.environ, "PYTHONIOENCODING": "UTF-8"}
+
+
+def _run_cli(args, *, input=None):
     cmd = [sys.executable, "-m", "korean_romanizer.cli", *args]
-    return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+    return subprocess.run(
+        cmd,
+        input=input,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        env=UTF8_ENV,
+        timeout=10,
+    )
 
 
-@pytest.mark.parametrize("text", [
-    "안녕하세요",
-    "아이유 방탄소년단",
-    "구미, 영동",
-])
+@pytest.mark.parametrize(
+    "text",
+    [
+        "안녕하세요",
+        "아이유 방탄소년단",
+        "구미, 영동",
+        "구미,\t영동   서울!!",
+    ],
+)
 def test_cli_matches_library(text):
-    expected = Romanizer(text).romanize().strip()
     args = text.split()
+    expected = Romanizer(" ".join(args)).romanize().strip()
     proc = _run_cli(args)
     assert proc.returncode == 0
+    assert proc.stderr == ""
     assert proc.stdout.strip() == expected
 
 
 def test_cli_help():
     proc = _run_cli(["-h"])
     assert proc.returncode == 0
+    assert proc.stderr == ""
     assert "usage" in proc.stdout.lower()
+
+
+@pytest.mark.parametrize("stdin", [None, "안녕하세요\n"])
+def test_cli_no_args_shows_usage(stdin):
+    proc = _run_cli([], input=stdin)
+    assert proc.returncode != 0
+    assert "usage" in proc.stderr.lower()
+
+
+def test_cli_long_input():
+    text = ("안녕하세요 " * 1000).strip()
+    args = text.split()
+    expected = Romanizer(" ".join(args)).romanize().strip()
+    proc = _run_cli(args)
+    assert proc.returncode == 0
+    assert proc.stderr == ""
+    assert proc.stdout.strip() == expected
 
 
 def test_console_script_smoke():
@@ -40,9 +74,21 @@ def test_console_script_smoke():
         if candidate.exists():
             exe = str(candidate)
     if not exe:
+        candidate = Path(sys.executable).with_name("kroman.exe")
+        if candidate.exists():
+            exe = str(candidate)
+    if not exe:
         pytest.skip("kroman console script not installed")
-    env = {**os.environ, "PYTHONIOENCODING": "UTF-8"}
-    proc = subprocess.run([exe, "안녕하세요"], capture_output=True, text=True, check=False, env=env)
+    proc = subprocess.run(
+        [exe, "안녕하세요"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        env=UTF8_ENV,
+        timeout=10,
+    )
     expected = Romanizer("안녕하세요").romanize().strip()
     assert proc.returncode == 0
+    assert proc.stderr == ""
     assert proc.stdout.strip() == expected

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@ import os
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
 import pytest
 from korean_romanizer.romanizer import Romanizer
@@ -34,6 +35,10 @@ def test_cli_help():
 
 def test_console_script_smoke():
     exe = shutil.which("kroman")
+    if not exe:
+        candidate = Path(sys.executable).with_name("kroman")
+        if candidate.exists():
+            exe = str(candidate)
     if not exe:
         pytest.skip("kroman console script not installed")
     env = {**os.environ, "PYTHONIOENCODING": "UTF-8"}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,43 @@
+import os
+import shutil
+import subprocess
+import sys
+
+import pytest
+from korean_romanizer.romanizer import Romanizer
+
+
+def _run_cli(args):
+    env = {**os.environ, "PYTHONIOENCODING": "UTF-8"}
+    cmd = [sys.executable, "-m", "korean_romanizer.cli", *args]
+    return subprocess.run(cmd, capture_output=True, text=True, check=False, env=env)
+
+
+@pytest.mark.parametrize("text", [
+    "안녕하세요",
+    "아이유 방탄소년단",
+    "구미, 영동",
+])
+def test_cli_matches_library(text):
+    expected = Romanizer(text).romanize().strip()
+    args = text.split()
+    proc = _run_cli(args)
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == expected
+
+
+def test_cli_help():
+    proc = _run_cli(["-h"])
+    assert proc.returncode == 0
+    assert "usage" in proc.stdout.lower()
+
+
+def test_console_script_smoke():
+    exe = shutil.which("kroman")
+    if not exe:
+        pytest.skip("kroman console script not installed")
+    env = {**os.environ, "PYTHONIOENCODING": "UTF-8"}
+    proc = subprocess.run([exe, "안녕하세요"], capture_output=True, text=True, check=False, env=env)
+    expected = Romanizer("안녕하세요").romanize().strip()
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == expected


### PR DESCRIPTION
## Summary
- add end-to-end CLI tests comparing CLI output to library
- smoke test console script if installed

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae081a338c8333a2cd132bad6377c3