### PR TITLE
[codex] Add development tooling bootstrap

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -26,15 +26,13 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 pytest
-        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-        pip install .
+        python -m pip install -e ".[dev]"
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
       run: |
-        pytest
+        python -m pytest

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,16 +20,15 @@ called out in release notes.
 
 ## Commands
 
-Current baseline:
+Set up a local development checkout:
+
+- Install dev tooling: `python3 -m pip install -e ".[dev]"`
 
 - Run tests: `python3 -m pytest`
 - Run CLI smoke test: `python3 -m korean_romanizer.cli 안녕하세요`
-
-After development tooling is added:
-
 - Run coverage: `python3 -m pytest --cov=korean_romanizer`
 - Run linting: `ruff check .`
-- Run formatting: `ruff format .`
+- Format code only in a dedicated formatting PR: `ruff format .`
 - Run type checks: `mypy korean_romanizer`
 - Build package: `python3 -m build`
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,24 @@ r.romanize()
 # returns 'annyeonghaseyo'
 ```
 
+## Development
+
+Install the local development tools with the `dev` extra:
+
+```bash
+python3 -m pip install -e ".[dev]"
+```
+
+Useful checks:
+
+```bash
+python3 -m pytest
+python3 -m pytest --cov=korean_romanizer
+ruff check .
+mypy korean_romanizer
+python3 -m build
+```
+
 ## Releasing
 
 Publishing to PyPI is automated using GitHub Actions. Pushing a version tag or

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,32 @@
 [build-system]
 requires = ["setuptools>=42", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = ["tests"]
+
+[tool.coverage.run]
+branch = true
+source = ["korean_romanizer"]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = true
+
+[tool.ruff]
+line-length = 127
+target-version = "py310"
+
+[tool.ruff.lint]
+# Match the current CI hard-fail flake8 rules; broaden after cleanup PRs.
+select = ["E9", "F63", "F7", "F82"]
+
+[tool.mypy]
+python_version = "3.10"
+warn_unused_configs = true
+
+[[tool.mypy.overrides]]
+module = "korean_romanizer.syllable"
+# Existing table stores None as a coda sentinel; model it explicitly later.
+disable_error_code = ["arg-type"]

--- a/setup.py
+++ b/setup.py
@@ -25,4 +25,14 @@ setup(
       'kroman=korean_romanizer.cli:main',
     ],
   },
+  extras_require={
+    'dev': [
+      'build>=1.2',
+      'flake8>=7.0',
+      'mypy>=1.10',
+      'pytest>=8.0',
+      'pytest-cov>=5.0',
+      'ruff>=0.6',
+    ],
+  },
 )


### PR DESCRIPTION
## Summary

- Add a `dev` extra with pytest, pytest-cov, flake8, ruff, mypy, and build tooling.
- Add baseline pytest, coverage, ruff, and mypy config in `pyproject.toml`.
- Document local development commands in README and AGENTS.md.
- Update the existing test workflow to install from `.[dev]` and invoke tools through `python -m`.

## Scope

This is tooling-only. It does not modify romanization source behavior or tests.

## Validation

Using the temporary local dependency target because this machine still has no global `pip`:

- `python3 -m pip install --target /tmp/kroman-dev-deps ".[dev]"` passed
- `python3 -m pytest` passed: 19 passed, 1 skipped
- `python3 -m pytest --cov=korean_romanizer` passed: 83% total coverage
- `python3 -m ruff check .` passed
- `python3 -m mypy korean_romanizer` passed
- `python3 -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics` passed
- `python3 -m build` passed

Notes:

- `python3 -m build` still emits pre-existing setuptools metadata warnings for later packaging cleanup.
- `ruff format --check .` reports existing formatting drift, so AGENTS.md now says formatting should happen only in a dedicated formatting PR.