### PR TITLE
[codex] Harden application CI workflow

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -1,4 +1,5 @@
-# This workflow will install Python dependencies, run tests and lint with a single version of Python
+# This workflow installs development dependencies, runs the test matrix, and
+# checks the repository quality gates.
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python application
@@ -13,26 +14,48 @@ permissions:
   contents: read
 
 jobs:
-  build:
+  test:
+    name: Test Python ${{ matrix.python-version }}
 
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
+    - uses: actions/checkout@v4
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v5
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
+        cache: pip
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         python -m pip install -e ".[dev]"
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        python -m flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        python -m flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
     - name: Test with pytest
+      run: python -m pytest
+
+  quality:
+    name: Quality gates
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v4
+    - name: Set up Python 3.10
+      uses: actions/setup-python@v5
+      with:
+        python-version: "3.10"
+        cache: pip
+    - name: Install dependencies
       run: |
-        python -m pytest
+        python -m pip install --upgrade pip
+        python -m pip install -e ".[dev]"
+    - name: Lint with ruff
+      run: python -m ruff check .
+    - name: Type check with mypy
+      run: python -m mypy korean_romanizer
+    - name: Build package
+      run: python -m build


### PR DESCRIPTION
## Summary

- Split the application workflow into a Python-version test matrix and a separate quality-gates job.
- Test on Python 3.10, 3.11, 3.12, and 3.13.
- Update the application workflow to `actions/checkout@v4` and `actions/setup-python@v5` with pip caching.
- Run the documented quality commands in CI: `ruff check .`, `mypy korean_romanizer`, and `python -m build`.

## Scope

This PR changes only `.github/workflows/python-app.yml`.

It does not modify romanization source behavior, tests, package metadata, or the PyPI publish workflow.

## Validation

Local command validation using the existing temporary dev dependency target:

- `python3 -m pytest` passed: 19 passed, 1 skipped
- `python3 -m ruff check .` passed
- `python3 -m mypy korean_romanizer` passed
- `python3 -m build` passed

Notes:

- `python3 -m build` still emits the pre-existing setuptools metadata warnings noted in the previous PR.
- A local YAML parser/actionlint tool is not installed in this environment, so workflow syntax will be finally validated by GitHub Actions on this PR.