### PR TITLE
[codex] Simplify romanizer character handling

### DIFF
--- a/korean_romanizer/romanizer.py
+++ b/korean_romanizer/romanizer.py
@@ -1,5 +1,3 @@
-import re
-
 from korean_romanizer.syllable import (
     Syllable,
     unicode_compatible_consonants,
@@ -107,34 +105,43 @@ compat_onset = {
     comp: onset[unicode_initial[i]]
     for i, comp in enumerate(unicode_compatible_consonants)
 }
-    
+
+
+def _is_romanizable_hangul(char):
+    return '가' <= char <= '힣' or 'ㄱ' <= char <= 'ㅣ'
+
+
+def _romanize_non_syllable(char):
+    if char in vowel:
+        return vowel[char]
+    elif char in onset:
+        return onset[char]
+    elif char in compat_onset:
+        return compat_onset[char]
+    else:
+        return char
+
+
+def _romanize_syllable(char):
+    syllable = Syllable(char)
+
+    if not syllable.medial and not syllable.final:
+        return _romanize_non_syllable(char)
+
+    return onset[syllable.initial] + vowel[syllable.medial] + coda[syllable.final]
+
+
 class Romanizer(object):
     def __init__(self, text):
         self.text = text
 
     def romanize(self):
         pronounced = Pronouncer(self.text).pronounced
-        hangul = r"[가-힣ㄱ-ㅣ]"
-        _romanized = ""
+        romanized = []
         for char in pronounced:
-            if (re.match(hangul, char)):
-                s = Syllable(char)
-
-                if not s.medial and not s.final:
-                    # s is NOT a full syllable (e.g. characters)
-                    if char in vowel:
-                        _romanized += vowel[char]
-                    elif char in onset:
-                        _romanized += onset[char]
-                    elif char in compat_onset:
-                        _romanized += compat_onset[char]
-                    else:
-                        _romanized += char
-                else:
-                    # s is a full syllable
-                    _romanized += onset[s.initial] + vowel[s.medial] + coda[s.final]
-
+            if _is_romanizable_hangul(char):
+                romanized.append(_romanize_syllable(char))
             else:
-                _romanized += char
+                romanized.append(char)
 
-        return _romanized
+        return ''.join(romanized)


### PR DESCRIPTION
## Summary

- Remove the per-character `re.match()` path from `Romanizer.romanize()`.
- Add small private helpers for the romanizable Hangul range and per-character romanization.
- Accumulate romanized chunks in a list and join once at the end.

## Scope

This is intended as a behavior-preserving internal cleanup.

It does not change romanization tables, pronunciation rules, tests, package metadata, CI, or release setup.

## Validation

Local validation using the existing temporary dev dependency target:

- `python3 -m pytest` passed: 59 passed, 1 skipped
- `python3 -m pytest --cov=korean_romanizer` passed: 85% total coverage
- `python3 -m ruff check .` passed
- `python3 -m mypy korean_romanizer` passed
- `python3 -m build` passed
- `git diff --check` passed

Benchmark context:

- Sample text: mixed Korean and ASCII phrase repeated 200 times
- Best of 5 repeats, 200 romanization runs per repeat
- `master`: 2.4471s
- this branch: 2.1130s
- ratio: 0.863x

Notes:

- `python3 -m build` still emits the pre-existing setuptools metadata warnings from earlier PRs.