### PR TITLE
[codex] Fix RR liquid and nasal assimilation

### DIFF
--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -139,6 +139,13 @@ Packaging and release gaps:
 - The algorithm has no morphology or word-boundary model. Some Korean
   romanization rules depend on morpheme boundaries, proper nouns, names, or
   conventional spellings, which a pure character-neighborhood pass cannot infer.
+- Revised Romanization also has transcription special provisions that are not
+  pure pronunciation rules. For example, `왕십리[왕심니] Wangsimni` follows
+  pronounced assimilation, while administrative-unit examples such as
+  `인왕리 Inwang-ri` preserve the `리` spelling and do not transcribe sound
+  changes around the administrative-unit boundary. The current implementation
+  should treat source-backed examples as guarded compatibility data until a
+  dedicated proper-name/admin-unit layer exists.
 - Proper nouns should probably not be handled by hidden guesses in the core
   transliterator. A safer approach is an optional override layer: keep the
   default algorithm deterministic, then allow callers or a curated data file to
@@ -281,6 +288,10 @@ Scope:
   - nasal and liquid assimilation such as `종로`, `신라`, `울릉`, and `대관령`;
   - remaining double-final and `ㅎ` edge cases.
 - Back each rule family with official examples or a checked golden corpus.
+- Keep standard-pronunciation fixes separate from RR special provisions for
+  proper names and administrative units. Add source-backed examples first, then
+  move toward an explicit override or boundary model instead of broad suffix
+  heuristics.
 - Mark behavior-changing releases clearly.
 
 Validation:

--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -22,9 +22,47 @@ FINAL_N = 'ᆫ'
 FINAL_NG = 'ᆼ'
 FINAL_RIEUL = 'ᆯ'
 
+# Standard Pronunciation Rule Article 20 exceptions where ㄴ+ㄹ is pronounced
+# ㄴ+ㄴ, not ㄹ+ㄹ. 신문로 is an official RR adjacent-assimilation example.
+N_R_TO_N_BOUNDARY_WORDS = (
+    '의견란',
+    '임진란',
+    '생산량',
+    '결단력',
+    '공권력',
+    '동원령',
+    '상견례',
+    '횡단로',
+    '이원론',
+    '입원료',
+    '구근류',
+    '신문로',
+)
+
+
+def _find_n_r_to_n_boundaries(text):
+    boundaries = set()
+
+    for word in N_R_TO_N_BOUNDARY_WORDS:
+        start = text.find(word)
+        while start != -1:
+            for offset in range(len(word) - 1):
+                syllable = Syllable(word[offset])
+                next_syllable = Syllable(word[offset + 1])
+                if (
+                    syllable.final == FINAL_N
+                    and next_syllable.initial == INITIAL_RIEUL
+                ):
+                    boundaries.add(start + offset)
+
+            start = text.find(word, start + 1)
+
+    return boundaries
+
 
 class Pronouncer(object):
     def __init__(self, text):
+        self._n_r_to_n_boundaries = _find_n_r_to_n_boundaries(text)
         self._syllables = [Syllable(char) for char in text]
         self.pronounced = ''.join([str(c) for c in self.final_substitute()])
 
@@ -124,11 +162,11 @@ class Pronouncer(object):
                 elif (
                     syllable.final == FINAL_N
                     and next_syllable.initial == INITIAL_RIEUL
-                    # 신문로[신문노] needs morphology-aware handling; leave
-                    # 로-suffix cases out of this narrow liquidization rule.
-                    and next_syllable.char != '로'
                 ):
-                    syllable.final = FINAL_RIEUL
+                    if idx in self._n_r_to_n_boundaries:
+                        next_syllable.initial = INITIAL_N
+                    else:
+                        syllable.final = FINAL_RIEUL
                 elif syllable.final == FINAL_RIEUL and next_syllable.initial == INITIAL_N:
                     next_syllable.initial = INITIAL_RIEUL
                     

--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -34,6 +34,15 @@ FINAL_BEFORE_RIEUL_TO_PRONOUNCED_FINAL = {
     FINAL_P: FINAL_M,
 }
 
+# RR Special Provision 5 preserves administrative units such as 리 as "ri";
+# assimilated sound changes before or after that boundary are not transcribed.
+# This project does not yet emit proper-name capitalization or admin-unit
+# hyphens, so this table only protects source-backed examples in the current
+# lowercase/no-hyphen style.
+RR_ADMIN_UNIT_RI_WORDS = (
+    '인왕리',
+)
+
 # Standard Pronunciation Rule Article 20 exceptions where ㄴ+ㄹ is pronounced
 # ㄴ+ㄴ, not ㄹ+ㄹ. 신문로 is an official RR adjacent-assimilation example.
 N_R_TO_N_BOUNDARY_WORDS = (
@@ -72,9 +81,23 @@ def _find_n_r_to_n_boundaries(text):
     return boundaries
 
 
+def _find_rieul_assimilation_preserved_boundaries(text):
+    boundaries = set()
+
+    for word in RR_ADMIN_UNIT_RI_WORDS:
+        start = text.find(word)
+        while start != -1:
+            boundaries.add(start + len(word) - 2)
+            start = text.find(word, start + 1)
+
+    return boundaries
+
+
 class Pronouncer(object):
     def __init__(self, text):
         self._n_r_to_n_boundaries = _find_n_r_to_n_boundaries(text)
+        self._rieul_assimilation_preserved_boundaries = (
+            _find_rieul_assimilation_preserved_boundaries(text))
         self._syllables = [Syllable(char) for char in text]
         self.pronounced = ''.join([str(c) for c in self.final_substitute()])
 
@@ -170,7 +193,10 @@ class Pronouncer(object):
             # and nasals, e.g. 종로[종노], 왕십리[왕심니], 신라[실라],
             # 별내[별래].
             if next_syllable:
-                if next_syllable.initial == INITIAL_RIEUL:
+                if (
+                    next_syllable.initial == INITIAL_RIEUL
+                    and idx not in self._rieul_assimilation_preserved_boundaries
+                ):
                     pronounced_final = FINAL_BEFORE_RIEUL_TO_PRONOUNCED_FINAL.get(
                         syllable.final)
                     if pronounced_final:

--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -16,6 +16,11 @@ double_consonant_final = {
 }
 
 NULL_CONSONANT = 'ᄋ'
+INITIAL_N = 'ᄂ'
+INITIAL_RIEUL = 'ᄅ'
+FINAL_N = 'ᆫ'
+FINAL_NG = 'ᆼ'
+FINAL_RIEUL = 'ᆯ'
 
 
 class Pronouncer(object):
@@ -110,6 +115,22 @@ class Pronouncer(object):
                 syllable.final = double_consonant[0]
                 next_syllable.initial = next_syllable.final_to_initial(
                     double_consonant[1])
+
+            # Revised Romanization follows pronounced forms for adjacent liquids
+            # and nasals, e.g. 종로[종노], 신라[실라], 별내[별래].
+            if next_syllable:
+                if syllable.final == FINAL_NG and next_syllable.initial == INITIAL_RIEUL:
+                    next_syllable.initial = INITIAL_N
+                elif (
+                    syllable.final == FINAL_N
+                    and next_syllable.initial == INITIAL_RIEUL
+                    # 신문로[신문노] needs morphology-aware handling; leave
+                    # 로-suffix cases out of this narrow liquidization rule.
+                    and next_syllable.char != '로'
+                ):
+                    syllable.final = FINAL_RIEUL
+                elif syllable.final == FINAL_RIEUL and next_syllable.initial == INITIAL_N:
+                    next_syllable.initial = INITIAL_RIEUL
                     
             # 5. 홑받침이나 쌍받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
             # 제 음가대로 뒤 음절 첫소리로 옮겨 발음한다.

--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -18,9 +18,21 @@ double_consonant_final = {
 NULL_CONSONANT = 'ᄋ'
 INITIAL_N = 'ᄂ'
 INITIAL_RIEUL = 'ᄅ'
+FINAL_K = 'ᆨ'
+FINAL_M = 'ᆷ'
 FINAL_N = 'ᆫ'
 FINAL_NG = 'ᆼ'
+FINAL_P = 'ᆸ'
 FINAL_RIEUL = 'ᆯ'
+
+# Standard Pronunciation Rule Article 19: initial ㄹ is pronounced ㄴ after
+# ㄱ, ㅁ, ㅂ, and ㅇ; ㄱ and ㅂ also nasalize before the resulting ㄴ.
+FINAL_BEFORE_RIEUL_TO_PRONOUNCED_FINAL = {
+    FINAL_K: FINAL_NG,
+    FINAL_M: FINAL_M,
+    FINAL_NG: FINAL_NG,
+    FINAL_P: FINAL_M,
+}
 
 # Standard Pronunciation Rule Article 20 exceptions where ㄴ+ㄹ is pronounced
 # ㄴ+ㄴ, not ㄹ+ㄹ. 신문로 is an official RR adjacent-assimilation example.
@@ -155,19 +167,24 @@ class Pronouncer(object):
                     double_consonant[1])
 
             # Revised Romanization follows pronounced forms for adjacent liquids
-            # and nasals, e.g. 종로[종노], 신라[실라], 별내[별래].
+            # and nasals, e.g. 종로[종노], 왕십리[왕심니], 신라[실라],
+            # 별내[별래].
             if next_syllable:
-                if syllable.final == FINAL_NG and next_syllable.initial == INITIAL_RIEUL:
-                    next_syllable.initial = INITIAL_N
-                elif (
-                    syllable.final == FINAL_N
-                    and next_syllable.initial == INITIAL_RIEUL
-                ):
-                    if idx in self._n_r_to_n_boundaries:
+                if next_syllable.initial == INITIAL_RIEUL:
+                    pronounced_final = FINAL_BEFORE_RIEUL_TO_PRONOUNCED_FINAL.get(
+                        syllable.final)
+                    if pronounced_final:
+                        syllable.final = pronounced_final
                         next_syllable.initial = INITIAL_N
-                    else:
-                        syllable.final = FINAL_RIEUL
-                elif syllable.final == FINAL_RIEUL and next_syllable.initial == INITIAL_N:
+                    elif syllable.final == FINAL_N:
+                        if idx in self._n_r_to_n_boundaries:
+                            next_syllable.initial = INITIAL_N
+                        else:
+                            syllable.final = FINAL_RIEUL
+                elif (
+                    syllable.final == FINAL_RIEUL
+                    and next_syllable.initial == INITIAL_N
+                ):
                     next_syllable.initial = INITIAL_RIEUL
                     
             # 5. 홑받침이나 쌍받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,

--- a/korean_romanizer/romanizer.py
+++ b/korean_romanizer/romanizer.py
@@ -6,6 +6,9 @@ from korean_romanizer.syllable import (
 from korean_romanizer.pronouncer import Pronouncer
 from korean_romanizer.tables import coda, compat_onset, onset, vowel
 
+INITIAL_RIEUL = 'ᄅ'
+FINAL_RIEUL = 'ᆯ'
+
 
 def _is_romanizable_hangul(char):
     return '가' <= char <= '힣' or 'ㄱ' <= char <= 'ㅣ'
@@ -22,13 +25,26 @@ def _romanize_non_syllable(char):
         return char
 
 
-def _romanize_syllable(char):
+def _romanize_initial(syllable, previous_syllable):
+    if (
+        syllable.initial == INITIAL_RIEUL
+        and previous_syllable
+        and previous_syllable.final == FINAL_RIEUL
+    ):
+        return 'l'
+
+    return onset[syllable.initial]
+
+
+def _romanize_syllable(char, previous_syllable=None):
     syllable = Syllable(char)
 
     if not syllable.medial and not syllable.final:
-        return _romanize_non_syllable(char)
+        return _romanize_non_syllable(char), None
 
-    return onset[syllable.initial] + vowel[syllable.medial] + coda[syllable.final]
+    romanized = _romanize_initial(syllable, previous_syllable)
+    romanized += vowel[syllable.medial] + coda[syllable.final]
+    return romanized, syllable
 
 
 class Romanizer(object):
@@ -38,10 +54,14 @@ class Romanizer(object):
     def romanize(self):
         pronounced = Pronouncer(self.text).pronounced
         romanized = []
+        previous_syllable = None
         for char in pronounced:
             if _is_romanizable_hangul(char):
-                romanized.append(_romanize_syllable(char))
+                romanized_char, previous_syllable = _romanize_syllable(
+                    char, previous_syllable)
+                romanized.append(romanized_char)
             else:
                 romanized.append(char)
+                previous_syllable = None
 
         return ''.join(romanized)

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -47,7 +47,6 @@ def test_jamo_current_behavior(text, expected):
     ("text", "expected"),
     [
         ("같이", "gati"),
-        ("신문로", "sinmunro"),
     ],
 )
 def test_known_rr_edge_cases_current_behavior(text, expected):

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -47,10 +47,7 @@ def test_jamo_current_behavior(text, expected):
     ("text", "expected"),
     [
         ("같이", "gati"),
-        ("종로", "jongro"),
-        ("신라", "sinra"),
-        ("울릉", "ulreung"),
-        ("대관령", "daegwanryeong"),
+        ("신문로", "sinmunro"),
     ],
 )
 def test_known_rr_edge_cases_current_behavior(text, expected):

--- a/tests/test_romanizer.py
+++ b/tests/test_romanizer.py
@@ -59,7 +59,7 @@ def test_double_consonant_final_and_next_syllable_null_initial():
 
 def test_double_consonant_final_and_next_syllable_not_null_initial():
     assert romanize("앉고싶다") == "angosipda"
-    assert romanize("뚫리다") == "ttulrida"
+    assert romanize("뚫리다") == "ttullida"
     assert romanize("칡뿌리") == "chikppuri"
     
 

--- a/tests/test_rr_correctness.py
+++ b/tests/test_rr_correctness.py
@@ -73,6 +73,13 @@ def test_rieul_to_n_after_nasal_and_stop_codas_rr_correctness(text, expected):
     assert romanize(text) == expected
 
 
+def test_administrative_unit_ri_preserves_rr_spelling():
+    # Official RR is Inwang-ri. This project currently omits proper-name
+    # capitalization and administrative-unit hyphenation, so assert inwangri.
+    assert romanize("인왕리") == "inwangri"
+    assert romanize("왕십리") == "wangsimni"
+
+
 @pytest.mark.parametrize(
     ("text", "expected"),
     [

--- a/tests/test_rr_correctness.py
+++ b/tests/test_rr_correctness.py
@@ -1,0 +1,38 @@
+import pytest
+
+from korean_romanizer.pronouncer import Pronouncer
+from korean_romanizer.romanizer import Romanizer
+
+
+def romanize(text):
+    return Romanizer(text).romanize()
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("종로", "jongno"),
+        ("신라", "silla"),
+        ("울릉", "ulleung"),
+        ("대관령", "daegwallyeong"),
+        ("별내", "byeollae"),
+    ],
+)
+def test_liquid_and_nasal_assimilation_rr_correctness(text, expected):
+    # Official NIKL RR examples include 종로[종노], 신라[실라],
+    # 울릉, 대관령[대괄령], and 별내[별래].
+    # See https://www.korean.go.kr/front_eng/roman/roman_01.do.
+    assert romanize(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("종로", "종노"),
+        ("신라", "실라"),
+        ("대관령", "대괄령"),
+        ("별내", "별래"),
+    ],
+)
+def test_liquid_and_nasal_assimilation_pronunciation(text, expected):
+    assert Pronouncer(text).pronounced == expected

--- a/tests/test_rr_correctness.py
+++ b/tests/test_rr_correctness.py
@@ -11,10 +11,15 @@ def romanize(text):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
+        ("난로", "nallo"),
         ("종로", "jongno"),
         ("신라", "silla"),
+        ("천리", "cheolli"),
         ("울릉", "ulleung"),
+        ("광한루", "gwanghallu"),
         ("대관령", "daegwallyeong"),
+        ("칼날", "kallal"),
+        ("물난리", "mullalli"),
         ("별내", "byeollae"),
     ],
 )
@@ -28,11 +33,62 @@ def test_liquid_and_nasal_assimilation_rr_correctness(text, expected):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
+        ("의견란", "uigyeonnan"),
+        ("임진란", "imjinnan"),
+        ("생산량", "saengsannyang"),
+        ("결단력", "gyeoldannyeok"),
+        ("공권력", "gonggwonnyeok"),
+        ("동원령", "dongwonnyeong"),
+        ("상견례", "sanggyeonnye"),
+        ("횡단로", "hoengdanno"),
+        ("이원론", "iwonnon"),
+        ("입원료", "ibwonnyo"),
+        ("구근류", "gugeunnyu"),
+        ("신문로", "sinmunno"),
+    ],
+)
+def test_n_r_to_n_exception_rr_correctness(text, expected):
+    # Standard Pronunciation Rule Article 20 lists cases where ㄴ+ㄹ
+    # is pronounced ㄴ+ㄴ. Official RR also includes 신문로[신문노].
+    assert romanize(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("난로", "날로"),
         ("종로", "종노"),
         ("신라", "실라"),
+        ("천리", "철리"),
+        ("광한루", "광할루"),
         ("대관령", "대괄령"),
+        ("칼날", "칼랄"),
+        ("물난리", "물랄리"),
         ("별내", "별래"),
     ],
 )
 def test_liquid_and_nasal_assimilation_pronunciation(text, expected):
+    assert Pronouncer(text).pronounced == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("의견란", "의견난"),
+        ("임진란", "임진난"),
+        ("생산량", "생산냥"),
+        ("결단력", "결단녁"),
+        ("공권력", "공권녁"),
+        ("동원령", "동원녕"),
+        ("상견례", "상견녜"),
+        ("횡단로", "횡단노"),
+        ("이원론", "이원논"),
+        ("입원료", "이붠뇨"),
+        ("구근류", "구근뉴"),
+        ("신문로", "신문노"),
+    ],
+)
+def test_n_r_to_n_exception_pronunciation(text, expected):
+    # This project intentionally avoids RR-irrelevant tensification, so these
+    # expected pronunciations focus on the ㄹ-to-ㄴ boundary change.
     assert Pronouncer(text).pronounced == expected

--- a/tests/test_rr_correctness.py
+++ b/tests/test_rr_correctness.py
@@ -56,6 +56,26 @@ def test_n_r_to_n_exception_rr_correctness(text, expected):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
+        ("강릉", "gangneung"),
+        ("담력", "damnyeok"),
+        ("막론", "mangnon"),
+        ("석류", "seongnyu"),
+        ("협력", "hyeomnyeok"),
+        ("법리", "beomni"),
+        ("십리", "simni"),
+        ("왕십리", "wangsimni"),
+    ],
+)
+def test_rieul_to_n_after_nasal_and_stop_codas_rr_correctness(text, expected):
+    # Standard Pronunciation Rule Article 19 changes ㄹ to ㄴ after
+    # ㄱ/ㅁ/ㅂ/ㅇ; ㄱ and ㅂ nasalize before that resulting ㄴ.
+    # Official RR includes 왕십리[왕심니].
+    assert romanize(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
         ("난로", "날로"),
         ("종로", "종노"),
         ("신라", "실라"),
@@ -91,4 +111,21 @@ def test_liquid_and_nasal_assimilation_pronunciation(text, expected):
 def test_n_r_to_n_exception_pronunciation(text, expected):
     # This project intentionally avoids RR-irrelevant tensification, so these
     # expected pronunciations focus on the ㄹ-to-ㄴ boundary change.
+    assert Pronouncer(text).pronounced == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("강릉", "강능"),
+        ("담력", "담녁"),
+        ("막론", "망논"),
+        ("석류", "성뉴"),
+        ("협력", "혐녁"),
+        ("법리", "범니"),
+        ("십리", "심니"),
+        ("왕십리", "왕심니"),
+    ],
+)
+def test_rieul_to_n_after_nasal_and_stop_codas_pronunciation(text, expected):
     assert Pronouncer(text).pronounced == expected


### PR DESCRIPTION
Authored by Codex.

## Summary
- Add RR correctness fixtures from the official NIKL Romanization of Korean examples for `종로`, `신문로`, `신라`, `울릉`, `대관령`, `별내`, `왕십리`, and `인왕리`.
- Apply adjacent liquid/nasal pronunciation substitutions before romanization so examples such as `종로`, `왕십리`, `신라`, `별내`, and `대관령` produce their official RR forms.
- Add Standard Pronunciation Rule Article 19 handling for initial `ㄹ` after `ㄱ/ㅁ/ㅂ/ㅇ`, including nasalization of preceding `ㄱ` and `ㅂ` before the resulting `ㄴ`.
- Add a source-backed Standard Pronunciation Rule Article 20 exception table for `ㄴ+ㄹ` words where the later `ㄹ` is pronounced as `ㄴ`, including `생산량`, `결단력`, `상견례`, `입원료`, `의견란`, `동원령`, and `신문로`.
- Preserve the official administrative-unit example `인왕리` as `inwangri` in this project’s existing lowercase/no-hyphen style, while keeping `왕십리 -> wangsimni` pronunciation-based.
- Document the longer-term need to separate standard pronunciation rules from RR special provisions for proper names and administrative units.
- Romanize pronounced `ㄹㄹ` across syllable boundaries as `ll`, including the existing `뚫리다` case.

## RR reference
- National Institute of Korean Language Romanization of Korean rules: https://www.korean.go.kr/front_eng/roman/roman_01.do
- National Institute of Korean Language Standard Pronunciation Rules Article 19 and Article 20: https://korean.go.kr/kornorms/regltn/regltnView.do?regltn_code=0002&regltn_no=346

## Validation
- `python3 -m pytest tests/test_rr_correctness.py` -> 60 passed
- `python3 -m pytest` -> 117 passed
- `python3 -m ruff check .` -> passed
- `python3 -m mypy korean_romanizer` -> passed
- `python3 -m pytest --cov=korean_romanizer` -> 117 passed, 89% coverage
- `python3 -m build` -> passed; existing `vcs_versioning` compatibility warnings still appear