### PR TITLE
[codex] Fix RR palatalization examples

### DIFF
--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -127,11 +127,12 @@ Packaging and release gaps:
 
 ## Likely Correctness Risks
 
-- The implementation does not cover all Revised Romanization edge cases. Direct
-  checks show outputs such as `같이 -> gati`, `종로 -> jongro`,
-  `신라 -> sinra`, `울릉 -> ulreung`, and `대관령 -> daegwanryeong`; several of
-  these are known assimilation or palatalization cases that likely need explicit
-  rules.
+- The implementation does not cover all Revised Romanization edge cases. Earlier
+  checks found known assimilation and palatalization gaps such as
+  `같이 -> gati`, `종로 -> jongro`, `신라 -> sinra`, `울릉 -> ulreung`, and
+  `대관령 -> daegwanryeong`. The liquid/nasal cases have since been moved into
+  RR correctness coverage; remaining rule families should continue to be fixed
+  in small, source-backed PRs.
 - Decomposed modern jamo are not consistently romanized. For example, `ᄀ` is
   currently preserved because the romanizer's Hangul regex covers precomposed
   Hangul and compatibility jamo, but not the modern choseong/jongseong Unicode

--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -28,12 +28,18 @@ FINAL_N = 'ᆫ'
 FINAL_NG = 'ᆼ'
 FINAL_P = 'ᆸ'
 FINAL_RIEUL = 'ᆯ'
+FINAL_RIEUL_T = 'ᆴ'
 FINAL_T = 'ᇀ'
 MEDIAL_I = 'ㅣ'
 
-PALATALIZED_INITIAL_BY_FINAL = {
-    FINAL_D: INITIAL_J,
-    FINAL_T: INITIAL_CH,
+PALATALIZED_BEFORE_I_BY_FINAL = {
+    FINAL_D: (None, INITIAL_J),
+    FINAL_T: (None, INITIAL_CH),
+    FINAL_RIEUL_T: (FINAL_RIEUL, INITIAL_CH),
+}
+
+PALATALIZED_BEFORE_HI_BY_FINAL = {
+    FINAL_D: (None, INITIAL_CH),
 }
 
 # Standard Pronunciation Rule Article 19: initial ㄹ is pronounced ㄴ after
@@ -71,6 +77,23 @@ N_R_TO_N_BOUNDARY_WORDS = (
     '신문로',
 )
 
+# Standard Pronunciation Rule Article 17 applies ㄷ/ㅌ palatalization before
+# the vowel ㅣ only in particle/suffix contexts. Keep this list source-backed
+# instead of applying a context-free ㄷ/ㅌ + 이 rule.
+PALATALIZATION_BOUNDARY_WORDS = (
+    '해돋이',
+    '같이',
+    '굳히다',
+    '곧이듣다',
+    '굳이',
+    '미닫이',
+    '땀받이',
+    '밭이',
+    '벼훑이',
+    '닫히다',
+    '묻히다',
+)
+
 
 def _find_n_r_to_n_boundaries(text):
     boundaries = set()
@@ -84,6 +107,35 @@ def _find_n_r_to_n_boundaries(text):
                 if (
                     syllable.final == FINAL_N
                     and next_syllable.initial == INITIAL_RIEUL
+                ):
+                    boundaries.add(start + offset)
+
+            start = text.find(word, start + 1)
+
+    return boundaries
+
+
+def _find_palatalization_boundaries(text):
+    boundaries = set()
+
+    for word in PALATALIZATION_BOUNDARY_WORDS:
+        start = text.find(word)
+        while start != -1:
+            for offset in range(len(word) - 1):
+                syllable = Syllable(word[offset])
+                next_syllable = Syllable(word[offset + 1])
+
+                if next_syllable.medial != MEDIAL_I:
+                    continue
+
+                if (
+                    next_syllable.initial == NULL_CONSONANT
+                    and syllable.final in PALATALIZED_BEFORE_I_BY_FINAL
+                ):
+                    boundaries.add(start + offset)
+                elif (
+                    next_syllable.initial == INITIAL_H
+                    and syllable.final in PALATALIZED_BEFORE_HI_BY_FINAL
                 ):
                     boundaries.add(start + offset)
 
@@ -109,21 +161,20 @@ def _apply_palatalization(syllable, next_syllable):
         return
 
     if next_syllable.initial == NULL_CONSONANT:
-        palatalized_initial = PALATALIZED_INITIAL_BY_FINAL.get(syllable.final)
-        if palatalized_initial:
-            syllable.final = None
-            next_syllable.initial = palatalized_initial
-    elif (
-        next_syllable.initial == INITIAL_H
-        and syllable.final in PALATALIZED_INITIAL_BY_FINAL
-    ):
-        syllable.final = None
-        next_syllable.initial = INITIAL_CH
+        replacement = PALATALIZED_BEFORE_I_BY_FINAL.get(syllable.final)
+    elif next_syllable.initial == INITIAL_H:
+        replacement = PALATALIZED_BEFORE_HI_BY_FINAL.get(syllable.final)
+    else:
+        replacement = None
+
+    if replacement:
+        syllable.final, next_syllable.initial = replacement
 
 
 class Pronouncer(object):
     def __init__(self, text):
         self._n_r_to_n_boundaries = _find_n_r_to_n_boundaries(text)
+        self._palatalization_boundaries = _find_palatalization_boundaries(text)
         self._rieul_assimilation_preserved_boundaries = (
             _find_rieul_assimilation_preserved_boundaries(text))
         self._syllables = [Syllable(char) for char in text]
@@ -209,6 +260,11 @@ class Pronouncer(object):
                 else:
                     syllable.final = without_ㅎ[syllable.final]
                         
+            # Revised Romanization follows pronounced palatalization, e.g.
+            # 해돋이[해도지], 같이[가치], 굳히다[구치다].
+            if next_syllable and idx in self._palatalization_boundaries:
+                _apply_palatalization(syllable, next_syllable)
+
             # 6. 겹받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
             # 뒤엣것만을 뒤 음절 첫소리로 옮겨 발음한다.(이 경우, ‘ㅅ’은 된소리로 발음함.)
             if syllable.final in double_consonant_final and next_syllable.initial == NULL_CONSONANT:
@@ -216,11 +272,6 @@ class Pronouncer(object):
                 syllable.final = double_consonant[0]
                 next_syllable.initial = next_syllable.final_to_initial(
                     double_consonant[1])
-
-            # Revised Romanization follows pronounced palatalization, e.g.
-            # 해돋이[해도지], 같이[가치], 굳히다[구치다].
-            if next_syllable:
-                _apply_palatalization(syllable, next_syllable)
 
             # Revised Romanization follows pronounced forms for adjacent liquids
             # and nasals, e.g. 종로[종노], 왕십리[왕심니], 신라[실라],

--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -16,14 +16,25 @@ double_consonant_final = {
 }
 
 NULL_CONSONANT = 'ᄋ'
+INITIAL_CH = 'ᄎ'
+INITIAL_H = 'ᄒ'
+INITIAL_J = 'ᄌ'
 INITIAL_N = 'ᄂ'
 INITIAL_RIEUL = 'ᄅ'
+FINAL_D = 'ᆮ'
 FINAL_K = 'ᆨ'
 FINAL_M = 'ᆷ'
 FINAL_N = 'ᆫ'
 FINAL_NG = 'ᆼ'
 FINAL_P = 'ᆸ'
 FINAL_RIEUL = 'ᆯ'
+FINAL_T = 'ᇀ'
+MEDIAL_I = 'ㅣ'
+
+PALATALIZED_INITIAL_BY_FINAL = {
+    FINAL_D: INITIAL_J,
+    FINAL_T: INITIAL_CH,
+}
 
 # Standard Pronunciation Rule Article 19: initial ㄹ is pronounced ㄴ after
 # ㄱ, ㅁ, ㅂ, and ㅇ; ㄱ and ㅂ also nasalize before the resulting ㄴ.
@@ -91,6 +102,23 @@ def _find_rieul_assimilation_preserved_boundaries(text):
             start = text.find(word, start + 1)
 
     return boundaries
+
+
+def _apply_palatalization(syllable, next_syllable):
+    if next_syllable.medial != MEDIAL_I:
+        return
+
+    if next_syllable.initial == NULL_CONSONANT:
+        palatalized_initial = PALATALIZED_INITIAL_BY_FINAL.get(syllable.final)
+        if palatalized_initial:
+            syllable.final = None
+            next_syllable.initial = palatalized_initial
+    elif (
+        next_syllable.initial == INITIAL_H
+        and syllable.final in PALATALIZED_INITIAL_BY_FINAL
+    ):
+        syllable.final = None
+        next_syllable.initial = INITIAL_CH
 
 
 class Pronouncer(object):
@@ -188,6 +216,11 @@ class Pronouncer(object):
                 syllable.final = double_consonant[0]
                 next_syllable.initial = next_syllable.final_to_initial(
                     double_consonant[1])
+
+            # Revised Romanization follows pronounced palatalization, e.g.
+            # 해돋이[해도지], 같이[가치], 굳히다[구치다].
+            if next_syllable:
+                _apply_palatalization(syllable, next_syllable)
 
             # Revised Romanization follows pronounced forms for adjacent liquids
             # and nasals, e.g. 종로[종노], 왕십리[왕심니], 신라[실라],

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -46,17 +46,6 @@ def test_jamo_current_behavior(text, expected):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("같이", "gati"),
-    ],
-)
-def test_known_rr_edge_cases_current_behavior(text, expected):
-    # These fixtures lock today's output; they are not claims of RR correctness.
-    assert romanize(text) == expected
-
-
-@pytest.mark.parametrize(
-    ("text", "expected"),
-    [
         ("좋습니다", "josseupnida"),
         ("놓고", "noko"),
         ("닿지", "dachi"),
@@ -79,7 +68,6 @@ def test_final_consonant_rules_current_behavior(text, expected):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
-        ("같이", "가티"),
         ("좋습니다", "조씁니다"),
         ("낳은", "나은"),
         ("싫어", "시러"),

--- a/tests/test_rr_correctness.py
+++ b/tests/test_rr_correctness.py
@@ -86,6 +86,9 @@ def test_administrative_unit_ri_preserves_rr_spelling():
         ("해돋이", "haedoji"),
         ("같이", "gachi"),
         ("굳히다", "guchida"),
+        ("굳이", "guji"),
+        ("밭이", "bachi"),
+        ("벼훑이", "byeohulchi"),
     ],
 )
 def test_palatalization_rr_correctness(text, expected):
@@ -93,6 +96,11 @@ def test_palatalization_rr_correctness(text, expected):
     # 같이[가치], and 굳히다[구치다].
     # See https://www.korean.go.kr/front_eng/roman/roman_01.do.
     assert romanize(text) == expected
+
+
+def test_palatalization_does_not_apply_to_lexical_ieo():
+    assert Pronouncer("곧이어").pronounced == "고디어"
+    assert romanize("곧이어") == "godieo"
 
 
 @pytest.mark.parametrize(
@@ -159,6 +167,9 @@ def test_rieul_to_n_after_nasal_and_stop_codas_pronunciation(text, expected):
         ("해돋이", "해도지"),
         ("같이", "가치"),
         ("굳히다", "구치다"),
+        ("굳이", "구지"),
+        ("밭이", "바치"),
+        ("벼훑이", "벼훌치"),
     ],
 )
 def test_palatalization_pronunciation(text, expected):

--- a/tests/test_rr_correctness.py
+++ b/tests/test_rr_correctness.py
@@ -83,6 +83,21 @@ def test_administrative_unit_ri_preserves_rr_spelling():
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
+        ("해돋이", "haedoji"),
+        ("같이", "gachi"),
+        ("굳히다", "guchida"),
+    ],
+)
+def test_palatalization_rr_correctness(text, expected):
+    # Official NIKL RR examples include 해돋이[해도지],
+    # 같이[가치], and 굳히다[구치다].
+    # See https://www.korean.go.kr/front_eng/roman/roman_01.do.
+    assert romanize(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
         ("난로", "날로"),
         ("종로", "종노"),
         ("신라", "실라"),
@@ -135,4 +150,16 @@ def test_n_r_to_n_exception_pronunciation(text, expected):
     ],
 )
 def test_rieul_to_n_after_nasal_and_stop_codas_pronunciation(text, expected):
+    assert Pronouncer(text).pronounced == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("해돋이", "해도지"),
+        ("같이", "가치"),
+        ("굳히다", "구치다"),
+    ],
+)
+def test_palatalization_pronunciation(text, expected):
     assert Pronouncer(text).pronounced == expected


### PR DESCRIPTION
Authored by Codex.

## Summary
- Add RR correctness fixtures for the official NIKL palatalization examples: `해돋이[해도지]`, `같이[가치]`, and `굳히다[구치다]`.
- Apply narrow `ㄷ`/`ㅌ` palatalization before `이`/`히` in `Pronouncer` so `Romanizer(text).romanize()` returns `haedoji`, `gachi`, and `guchida`.
- Move `같이` out of current-behavior characterization and into RR correctness coverage.
- Refresh the modernization plan note that liquid/nasal examples are now covered and remaining RR correctness work should stay small and source-backed.

## RR reference
- National Institute of Korean Language Romanization of Korean rules: https://www.korean.go.kr/front_eng/roman/roman_01.do

## Validation
- `python3 -m pytest tests/test_rr_correctness.py` -> 66 passed
- `python3 -m pytest` -> 121 passed
- `python3 -m ruff check .` -> passed
- `python3 -m mypy korean_romanizer` -> passed
- `python3 -m pytest --cov=korean_romanizer` -> 121 passed, 90% coverage
- `python3 -m build` -> passed; existing `vcs_versioning` warnings still appear
