### PR TITLE
Fix RR h aspiration example

### DIFF
--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -32,6 +32,7 @@ FINAL_RIEUL = 'ᆯ'
 FINAL_RIEUL_T = 'ᆴ'
 FINAL_T = 'ᇀ'
 MEDIAL_I = 'ㅣ'
+MEDIAL_YEO = 'ㅕ'
 
 PALATALIZED_BEFORE_I_BY_FINAL = {
     FINAL_D: (None, INITIAL_J),
@@ -100,10 +101,13 @@ PALATALIZATION_BOUNDARY_WORDS = (
 )
 
 # RR transcribes pronounced aspiration around ㅎ for source-backed examples such
-# as 잡혀[자펴]. It does not transcribe the same surface ㄱ/ㄷ/ㅂ+ㅎ pattern for
-# noun examples such as 묵호 and 집현전, so keep this boundary list explicit.
-H_ASPIRATION_BOUNDARY_WORDS = (
-    '잡혀',
+# as 잡혀[자펴]. The same 잡- + -히/-혀- boundary appears in inflected forms
+# such as 잡힌, 잡히다, 잡혔다, and 잡혔어.
+#
+# Keep this explicit instead of applying every ㄱ/ㄷ/ㅂ+ㅎ boundary, because RR
+# does not transcribe the aspirated sound in noun examples such as 묵호 and 집현전.
+H_ASPIRATION_BOUNDARY_PATTERNS = (
+    ('잡', (MEDIAL_I, MEDIAL_YEO)),
 )
 
 
@@ -130,19 +134,20 @@ def _find_n_r_to_n_boundaries(text):
 def _find_h_aspiration_boundaries(text):
     boundaries = set()
 
-    for word in H_ASPIRATION_BOUNDARY_WORDS:
-        start = text.find(word)
-        while start != -1:
-            for offset in range(len(word) - 1):
-                syllable = Syllable(word[offset])
-                next_syllable = Syllable(word[offset + 1])
-                if (
-                    syllable.final in ASPIRATED_BEFORE_H_BY_FINAL
-                    and next_syllable.initial == INITIAL_H
-                ):
-                    boundaries.add(start + offset)
+    for idx in range(len(text) - 1):
+        for stem_syllable, next_medials in H_ASPIRATION_BOUNDARY_PATTERNS:
+            if text[idx] != stem_syllable:
+                continue
 
-            start = text.find(word, start + 1)
+            syllable = Syllable(text[idx])
+            next_syllable = Syllable(text[idx + 1])
+            if (
+                syllable.final in ASPIRATED_BEFORE_H_BY_FINAL
+                and next_syllable.initial == INITIAL_H
+                and next_syllable.medial in next_medials
+            ):
+                boundaries.add(idx)
+                break
 
     return boundaries
 

--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -20,6 +20,7 @@ INITIAL_CH = 'ᄎ'
 INITIAL_H = 'ᄒ'
 INITIAL_J = 'ᄌ'
 INITIAL_N = 'ᄂ'
+INITIAL_P = 'ᄑ'
 INITIAL_RIEUL = 'ᄅ'
 FINAL_D = 'ᆮ'
 FINAL_K = 'ᆨ'
@@ -40,6 +41,10 @@ PALATALIZED_BEFORE_I_BY_FINAL = {
 
 PALATALIZED_BEFORE_HI_BY_FINAL = {
     FINAL_D: (None, INITIAL_CH),
+}
+
+ASPIRATED_BEFORE_H_BY_FINAL = {
+    FINAL_P: INITIAL_P,
 }
 
 # Standard Pronunciation Rule Article 19: initial ㄹ is pronounced ㄴ after
@@ -94,6 +99,13 @@ PALATALIZATION_BOUNDARY_WORDS = (
     '묻히다',
 )
 
+# RR transcribes pronounced aspiration around ㅎ for source-backed examples such
+# as 잡혀[자펴]. It does not transcribe the same surface ㄱ/ㄷ/ㅂ+ㅎ pattern for
+# noun examples such as 묵호 and 집현전, so keep this boundary list explicit.
+H_ASPIRATION_BOUNDARY_WORDS = (
+    '잡혀',
+)
+
 
 def _find_n_r_to_n_boundaries(text):
     boundaries = set()
@@ -107,6 +119,26 @@ def _find_n_r_to_n_boundaries(text):
                 if (
                     syllable.final == FINAL_N
                     and next_syllable.initial == INITIAL_RIEUL
+                ):
+                    boundaries.add(start + offset)
+
+            start = text.find(word, start + 1)
+
+    return boundaries
+
+
+def _find_h_aspiration_boundaries(text):
+    boundaries = set()
+
+    for word in H_ASPIRATION_BOUNDARY_WORDS:
+        start = text.find(word)
+        while start != -1:
+            for offset in range(len(word) - 1):
+                syllable = Syllable(word[offset])
+                next_syllable = Syllable(word[offset + 1])
+                if (
+                    syllable.final in ASPIRATED_BEFORE_H_BY_FINAL
+                    and next_syllable.initial == INITIAL_H
                 ):
                     boundaries.add(start + offset)
 
@@ -171,8 +203,16 @@ def _apply_palatalization(syllable, next_syllable):
         syllable.final, next_syllable.initial = replacement
 
 
+def _apply_h_aspiration(syllable, next_syllable):
+    aspirated_initial = ASPIRATED_BEFORE_H_BY_FINAL.get(syllable.final)
+    if aspirated_initial and next_syllable.initial == INITIAL_H:
+        syllable.final = None
+        next_syllable.initial = aspirated_initial
+
+
 class Pronouncer(object):
     def __init__(self, text):
+        self._h_aspiration_boundaries = _find_h_aspiration_boundaries(text)
         self._n_r_to_n_boundaries = _find_n_r_to_n_boundaries(text)
         self._palatalization_boundaries = _find_palatalization_boundaries(text)
         self._rieul_assimilation_preserved_boundaries = (
@@ -260,6 +300,11 @@ class Pronouncer(object):
                 else:
                     syllable.final = without_ㅎ[syllable.final]
                         
+            # RR transcribes source-backed ㅎ aspiration, e.g. 잡혀[자펴],
+            # while preserving noun examples such as 묵호 and 집현전.
+            if next_syllable and idx in self._h_aspiration_boundaries:
+                _apply_h_aspiration(syllable, next_syllable)
+
             # Revised Romanization follows pronounced palatalization, e.g.
             # 해돋이[해도지], 같이[가치], 굳히다[구치다].
             if next_syllable and idx in self._palatalization_boundaries:

--- a/tests/test_rr_correctness.py
+++ b/tests/test_rr_correctness.py
@@ -106,6 +106,35 @@ def test_palatalization_does_not_apply_to_lexical_ieo():
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
+        ("좋고", "joko"),
+        ("놓다", "nota"),
+        ("잡혀", "japyeo"),
+        ("낳지", "nachi"),
+    ],
+)
+def test_h_adjacency_rr_correctness(text, expected):
+    # Official NIKL RR examples include 좋고[조코], 놓다[노타],
+    # 잡혀[자펴], and 낳지[나치].
+    # See https://www.korean.go.kr/front_eng/roman/roman_01.do.
+    assert romanize(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("묵호", "mukho"),
+        ("집현전", "jiphyeonjeon"),
+    ],
+)
+def test_h_adjacency_noun_examples_do_not_transcribe_aspiration(text, expected):
+    # RR does not transcribe aspirated sounds in nouns where ㅎ follows
+    # ㄱ, ㄷ, or ㅂ, as in official examples 묵호 and 집현전.
+    assert romanize(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
         ("난로", "날로"),
         ("종로", "종노"),
         ("신라", "실라"),
@@ -173,4 +202,19 @@ def test_rieul_to_n_after_nasal_and_stop_codas_pronunciation(text, expected):
     ],
 )
 def test_palatalization_pronunciation(text, expected):
+    assert Pronouncer(text).pronounced == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("좋고", "조코"),
+        ("놓다", "노타"),
+        ("잡혀", "자펴"),
+        ("낳지", "나치"),
+        ("묵호", "묵호"),
+        ("집현전", "집현전"),
+    ],
+)
+def test_h_adjacency_pronunciation(text, expected):
     assert Pronouncer(text).pronounced == expected

--- a/tests/test_rr_correctness.py
+++ b/tests/test_rr_correctness.py
@@ -122,6 +122,20 @@ def test_h_adjacency_rr_correctness(text, expected):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
+        ("잡혀", "japyeo"),
+        ("잡히다", "japida"),
+        ("잡힌", "japin"),
+        ("잡혔다", "japyeotda"),
+        ("잡혔어", "japyeosseo"),
+    ],
+)
+def test_h_adjacency_japhida_inflections_rr_correctness(text, expected):
+    assert romanize(text) == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
         ("묵호", "mukho"),
         ("집현전", "jiphyeonjeon"),
     ],
@@ -217,4 +231,16 @@ def test_palatalization_pronunciation(text, expected):
     ],
 )
 def test_h_adjacency_pronunciation(text, expected):
+    assert Pronouncer(text).pronounced == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("잡혀", "자펴"),
+        ("잡히다", "자피다"),
+        ("잡힌", "자핀"),
+    ],
+)
+def test_h_adjacency_japhida_inflections_pronunciation(text, expected):
     assert Pronouncer(text).pronounced == expected


### PR DESCRIPTION
## Summary
- add RR correctness coverage for official ㅎ-adjacency examples: 좋고, 놓다, 잡혀, 낳지
- fix the source-backed 잡- + -히/-혀- boundary so forms such as 잡혀, 잡히다, 잡힌, 잡혔다, and 잡혔어 romanize without an extra h
- add guard coverage for official noun examples 묵호 and 집현전, where RR does not transcribe the aspirated sound

## Scope
This intentionally does not add a broad ㄱ/ㄷ/ㅂ + ㅎ heuristic. RR distinguishes source-backed aspiration examples from noun examples like 묵호 and 집현전, so this PR keeps the 잡- + -히/-혀- boundary explicit until the project has a morphology or pronunciation-override layer.

## Tests
- python3 -m pytest tests/test_rr_correctness.py -q
- python3 -m pytest -q
- python3 -m pytest --cov=korean_romanizer -q
- ruff check .
