### PR TITLE
Add functional romanize API and document compatibility

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,8 +8,9 @@ called out in release notes.
 
 ## Repository Map
 
-- `korean_romanizer/romanizer.py`: public `Romanizer(text).romanize()` flow and
-  per-character romanization flow.
+- `korean_romanizer/romanizer.py`: preferred public `romanize(text)` flow,
+  compatibility `Romanizer(text).romanize()` wrapper, and per-character
+  romanization flow.
 - `korean_romanizer/tables.py`: Revised Romanization vowel, onset, coda, and
   compatibility jamo tables.
 - `korean_romanizer/pronouncer.py`: context-sensitive pronunciation
@@ -37,6 +38,7 @@ Set up a local development checkout:
 ## Rules
 
 - Do not change romanization behavior without adding regression tests.
+- Keep `romanize(text)` as the preferred public API.
 - Keep `Romanizer(text).romanize()` backward compatible.
 - Keep the `kroman` console script backward compatible unless a CLI contract
   change is explicitly documented and tested.

--- a/README.md
+++ b/README.md
@@ -13,12 +13,31 @@ pip install korean_romanizer
 
 ### Basic Usage
 ```python
-from korean_romanizer.romanizer import Romanizer
+from korean_romanizer import romanize
 
-r = Romanizer("안녕하세요")
-r.romanize() 
-# returns 'annyeonghaseyo'
+romanize("안녕하세요")
+# returns "annyeonghaseyo"
 ```
+
+The existing class API remains supported for compatibility:
+
+```python
+from korean_romanizer import Romanizer
+
+Romanizer("안녕하세요").romanize()
+# returns "annyeonghaseyo"
+```
+
+Use the `kroman` command for shell workflows:
+
+```bash
+kroman 안녕하세요
+# annyeonghaseyo
+```
+
+`Pronouncer` and `Syllable` are also exported as lower-level compatibility
+APIs. Constants, tables, and helper functions are internal implementation
+details and should not be imported by application code.
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -28,12 +28,26 @@ Romanizer("안녕하세요").romanize()
 # returns "annyeonghaseyo"
 ```
 
+The formerly documented module import path also remains supported:
+
+```python
+from korean_romanizer.romanizer import Romanizer
+```
+
 Use the `kroman` command for shell workflows:
 
 ```bash
 kroman 안녕하세요
 # annyeonghaseyo
 ```
+
+Wildcard imports now follow the explicit public API in `__all__`:
+
+```python
+from korean_romanizer import *
+```
+
+This imports only `romanize`, `Romanizer`, `Pronouncer`, and `Syllable`.
 
 `Pronouncer` and `Syllable` are also exported as lower-level compatibility
 APIs. Constants, tables, and helper functions are internal implementation

--- a/korean_romanizer/__init__.py
+++ b/korean_romanizer/__init__.py
@@ -1,3 +1,5 @@
+"""Public package API for korean_romanizer."""
+
 from korean_romanizer.syllable import Syllable
 from korean_romanizer.pronouncer import Pronouncer
 from korean_romanizer.romanizer import Romanizer, romanize

--- a/korean_romanizer/__init__.py
+++ b/korean_romanizer/__init__.py
@@ -1,3 +1,10 @@
 from korean_romanizer.syllable import Syllable
 from korean_romanizer.pronouncer import Pronouncer
-from korean_romanizer.romanizer import Romanizer
+from korean_romanizer.romanizer import Romanizer, romanize
+
+__all__ = (
+    "romanize",
+    "Romanizer",
+    "Pronouncer",
+    "Syllable",
+)

--- a/korean_romanizer/cli.py
+++ b/korean_romanizer/cli.py
@@ -1,15 +1,16 @@
 import argparse
-from korean_romanizer.romanizer import Romanizer
+
+from korean_romanizer import romanize
 
 def main():
+    """Run the kroman command-line interface."""
     parser = argparse.ArgumentParser(description='Romanize Korean text.')
     parser.add_argument('text', nargs='+', help='The Korean text to be romanized.')
     args = parser.parse_args()
     
     text_to_romanize = " ".join(args.text)
     
-    r = Romanizer(text_to_romanize)
-    result = r.romanize()
+    result = romanize(text_to_romanize)
     print(result)
 
 if __name__ == '__main__':

--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -216,6 +216,8 @@ def _apply_h_aspiration(syllable, next_syllable):
 
 
 class Pronouncer(object):
+    """Apply Korean pronunciation substitutions before romanization."""
+
     def __init__(self, text):
         self._h_aspiration_boundaries = _find_h_aspiration_boundaries(text)
         self._n_r_to_n_boundaries = _find_n_r_to_n_boundaries(text)

--- a/korean_romanizer/romanizer.py
+++ b/korean_romanizer/romanizer.py
@@ -48,7 +48,7 @@ def _romanize_syllable(char, previous_syllable=None):
 
 
 def romanize(text: str) -> str:
-    """Return the Revised Romanization for Korean text."""
+    """Romanize Korean text using this package's rules."""
     pronounced = Pronouncer(text).pronounced
     romanized = []
     previous_syllable = None
@@ -71,4 +71,5 @@ class Romanizer(object):
         self.text = text
 
     def romanize(self):
+        """Romanize the stored text using the functional API."""
         return romanize(self.text)

--- a/korean_romanizer/romanizer.py
+++ b/korean_romanizer/romanizer.py
@@ -47,21 +47,28 @@ def _romanize_syllable(char, previous_syllable=None):
     return romanized, syllable
 
 
+def romanize(text: str) -> str:
+    """Return the Revised Romanization for Korean text."""
+    pronounced = Pronouncer(text).pronounced
+    romanized = []
+    previous_syllable = None
+    for char in pronounced:
+        if _is_romanizable_hangul(char):
+            romanized_char, previous_syllable = _romanize_syllable(
+                char, previous_syllable)
+            romanized.append(romanized_char)
+        else:
+            romanized.append(char)
+            previous_syllable = None
+
+    return ''.join(romanized)
+
+
 class Romanizer(object):
+    """Compatibility wrapper for romanizing Korean text."""
+
     def __init__(self, text):
         self.text = text
 
     def romanize(self):
-        pronounced = Pronouncer(self.text).pronounced
-        romanized = []
-        previous_syllable = None
-        for char in pronounced:
-            if _is_romanizable_hangul(char):
-                romanized_char, previous_syllable = _romanize_syllable(
-                    char, previous_syllable)
-                romanized.append(romanized_char)
-            else:
-                romanized.append(char)
-                previous_syllable = None
-
-        return ''.join(romanized)
+        return romanize(self.text)

--- a/korean_romanizer/syllable.py
+++ b/korean_romanizer/syllable.py
@@ -13,6 +13,8 @@ unicode_compatible_consonants = ['ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ'
 unicode_compatible_finals =     ['ᆨ', 'ᆩ', 'ᆫ', 'ᆮ', '_', 'ᆯ', 'ᆷ', 'ᆸ', '_', 'ᆺ', 'ᆻ', 'ᆼ', 'ᆽ', '_', 'ᆾ', 'ᆿ', 'ᇀ', 'ᇁ', 'ᇂ']
 
 class Syllable(object):
+    """Represent a Hangul syllable decomposed into jamo components."""
+
     def __init__(self, char):
         self.char = char
         _is_hangul, _separated = self.separate_syllable(char)

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -30,6 +30,19 @@ def test_all_exports_exact_public_api():
     assert korean_romanizer.__all__ == EXPECTED_ALL
 
 
+def test_wildcard_import_exports_only_public_api():
+    namespace = {}
+
+    exec("from korean_romanizer import *", namespace)
+
+    exported = {name for name in namespace if not name.startswith("__")}
+    assert exported == set(EXPECTED_ALL)
+    assert namespace["romanize"] is romanize
+    assert namespace["Romanizer"] is Romanizer
+    assert namespace["Pronouncer"] is Pronouncer
+    assert namespace["Syllable"] is Syllable
+
+
 def test_lower_level_compatibility_exports_remain_importable():
     assert Pronouncer("안녕하세요").pronounced
     assert Syllable("한").char == "한"

--- a/tests/test_public_api.py
+++ b/tests/test_public_api.py
@@ -1,0 +1,35 @@
+import korean_romanizer
+from korean_romanizer import Pronouncer, Romanizer, Syllable, romanize
+from korean_romanizer.romanizer import Romanizer as ModuleRomanizer
+from korean_romanizer.romanizer import romanize as module_romanize
+
+
+EXPECTED_ALL = (
+    "romanize",
+    "Romanizer",
+    "Pronouncer",
+    "Syllable",
+)
+
+
+def test_functional_api_output():
+    assert romanize("안녕하세요") == "annyeonghaseyo"
+
+
+def test_package_and_module_exports_are_identical():
+    assert romanize is module_romanize
+    assert Romanizer is ModuleRomanizer
+
+
+def test_class_api_matches_function():
+    text = "아이유 방탄소년단"
+    assert Romanizer(text).romanize() == romanize(text)
+
+
+def test_all_exports_exact_public_api():
+    assert korean_romanizer.__all__ == EXPECTED_ALL
+
+
+def test_lower_level_compatibility_exports_remain_importable():
+    assert Pronouncer("안녕하세요").pronounced
+    assert Syllable("한").char == "한"


### PR DESCRIPTION
## Summary

- Add `romanize(text: str) -> str` as the preferred public API and keep `Romanizer(text).romanize()` as a compatibility wrapper.
- Export the functional API through `korean_romanizer.__all__` alongside `Romanizer`, `Pronouncer`, and `Syllable`.
- Update the CLI to call `romanize(text)` without changing argument joining or output behavior.
- Refresh README usage docs, compatibility notes, and public API coverage.

## Compatibility notes

- `Romanizer.__init__` and `Romanizer.romanize()` signatures are unchanged.
- Existing named imports for `Romanizer`, `Pronouncer`, and `Syllable` remain supported.
- The formerly documented `from korean_romanizer.romanizer import Romanizer` path remains supported.
- `from korean_romanizer import *` now follows the explicit `__all__` contract and exposes only `romanize`, `Romanizer`, `Pronouncer`, and `Syllable`.
- `Pronouncer` and `Syllable` are documented as lower-level compatibility exports.
- Constants, tables, and helper functions are documented as internal implementation details.
- No romanization rules, runtime validation, dependencies, packaging behavior, or CLI contract changes were made.

## Validation

- `python3 -m pytest`: 153 passed, 1 skipped (`kroman` console script not on PATH)
- `python3 -m pytest --cov=korean_romanizer`: 153 passed, 1 skipped, 90% total coverage
- `ruff check .`: passed via installed `ruff.exe` because the Python user Scripts directory is not on PATH
- `mypy korean_romanizer`: passed via installed `mypy.exe` because the Python user Scripts directory is not on PATH
- `python3 -m build`: passed; built sdist and wheel