### PR TITLE
Move package metadata to pyproject.toml

### DIFF
--- a/.github/workflows/python-app.yml
+++ b/.github/workflows/python-app.yml
@@ -59,3 +59,5 @@ jobs:
       run: python -m mypy korean_romanizer
     - name: Build package
       run: python -m build
+    - name: Validate wheel metadata
+      run: python scripts/validate_wheel_metadata.py

--- a/README.md
+++ b/README.md
@@ -73,9 +73,8 @@ python3 -m build
 
 ## Releasing
 
-Publishing to PyPI is automated using GitHub Actions. Pushing a version tag or
-creating a GitHub release triggers the workflow in
+Publishing to PyPI is automated using GitHub Actions. Publishing a GitHub release
+triggers the workflow in
 `.github/workflows/python-publish.yml` which builds and uploads the package using
 the `PYPI_API_TOKEN` secret. The package version is derived from git tags using
-`setuptools_scm`, so create a new tag or GitHub release when publishing a new
-version.
+`setuptools_scm`, so create the version tag before publishing the GitHub release.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77.0.3", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,48 @@
 [build-system]
-requires = ["setuptools>=42", "setuptools_scm[toml]>=6.2"]
+requires = ["setuptools>=77", "setuptools_scm[toml]>=6.2"]
 build-backend = "setuptools.build_meta"
+
+[project]
+name = "korean_romanizer"
+dynamic = ["version"]
+description = "A Python library for Korean romanization"
+readme = "README.md"
+requires-python = ">=3.10"
+license = "GPL-3.0-or-later"
+authors = [
+  { name = "Ilkyu Ju", email = "ju.ilkyu@gmail.com" },
+]
+keywords = ["Korean", "Romanization", "Transliteration"]
+classifiers = [
+  "Development Status :: 3 - Alpha",
+  "Intended Audience :: Developers",
+  "Topic :: Software Development :: Libraries :: Python Modules",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+]
+
+[project.urls]
+Homepage = "https://github.com/osori/korean-romanizer"
+Repository = "https://github.com/osori/korean-romanizer"
+
+[project.optional-dependencies]
+dev = [
+  "build>=1.2",
+  "flake8>=7.0",
+  "mypy>=1.10",
+  "pytest>=8.0",
+  "pytest-cov>=5.0",
+  "ruff>=0.6",
+]
+
+[project.scripts]
+kroman = "korean_romanizer.cli:main"
+
+[tool.setuptools]
+packages = ["korean_romanizer"]
 
 [tool.setuptools_scm]
 

--- a/scripts/validate_wheel_metadata.py
+++ b/scripts/validate_wheel_metadata.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+import textwrap
+import zipfile
+from pathlib import Path
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+DIST_NAME = "korean_romanizer"
+EXPECTED_DEV_REQUIRES = (
+    "build>=1.2",
+    "flake8>=7.0",
+    "mypy>=1.10",
+    "pytest>=8.0",
+    "pytest-cov>=5.0",
+    "ruff>=0.6",
+)
+
+
+def run(command: list[str | Path], *, cwd: Path, capture_output: bool = False) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [str(part) for part in command],
+        cwd=cwd,
+        check=True,
+        text=True,
+        encoding="utf-8",
+        capture_output=capture_output,
+    )
+
+
+def venv_path(venv_dir: Path, executable: str) -> Path:
+    bin_dir = "Scripts" if os.name == "nt" else "bin"
+    suffix = ".exe" if os.name == "nt" and executable in {"python", "kroman"} else ""
+    return venv_dir / bin_dir / f"{executable}{suffix}"
+
+
+def build_wheel(dist_dir: Path) -> Path:
+    run([sys.executable, "-m", "build", "--wheel", "--outdir", dist_dir, PROJECT_ROOT], cwd=PROJECT_ROOT)
+    wheels = sorted(dist_dir.glob(f"{DIST_NAME}-*.whl"))
+    if len(wheels) != 1:
+        raise AssertionError(f"Expected exactly one {DIST_NAME} wheel, found: {wheels}")
+    return wheels[0]
+
+
+def validate_wheel_contents(wheel_path: Path) -> None:
+    blocked_prefixes = (".github/", "build/", "dist/", "docs/", "scripts/", "tests/")
+    with zipfile.ZipFile(wheel_path) as wheel:
+        names = wheel.namelist()
+
+    package_files = [name for name in names if name.startswith(f"{DIST_NAME}/")]
+    if not package_files:
+        raise AssertionError(f"Wheel does not contain the {DIST_NAME} package")
+
+    unexpected = sorted(name for name in names if name.startswith(blocked_prefixes))
+    if unexpected:
+        raise AssertionError(f"Wheel contains non-package project files: {unexpected}")
+
+
+def validate_installed_metadata(python: Path, work_dir: Path) -> None:
+    metadata_check = textwrap.dedent(
+        f"""
+        import importlib.metadata as metadata
+        import korean_romanizer
+        from korean_romanizer import romanize
+
+        dist = metadata.distribution("{DIST_NAME}")
+        package_metadata = dist.metadata
+
+        assert package_metadata["Name"] == "{DIST_NAME}", package_metadata["Name"]
+        assert package_metadata["Requires-Python"] == ">=3.10", package_metadata["Requires-Python"]
+        assert package_metadata["License-Expression"] == "GPL-3.0-or-later", package_metadata["License-Expression"]
+
+        console_scripts = metadata.entry_points().select(group="console_scripts")
+        kroman_scripts = [entry_point for entry_point in console_scripts if entry_point.name == "kroman"]
+        assert len(kroman_scripts) == 1, kroman_scripts
+        assert kroman_scripts[0].value == "korean_romanizer.cli:main", kroman_scripts[0].value
+
+        extras = set(package_metadata.get_all("Provides-Extra") or [])
+        assert "dev" in extras, extras
+
+        requirements = package_metadata.get_all("Requires-Dist") or []
+        expected_dev_requires = {EXPECTED_DEV_REQUIRES!r}
+        for expected_requirement in expected_dev_requires:
+            assert any(
+                requirement.startswith(expected_requirement) and 'extra == "dev"' in requirement
+                for requirement in requirements
+            ), requirements
+
+        assert korean_romanizer.romanize("안녕하세요") == "annyeonghaseyo"
+        assert romanize("안녕하세요") == "annyeonghaseyo"
+        """
+    )
+    run([python, "-c", metadata_check], cwd=work_dir)
+
+
+def validate_console_script(kroman: Path, work_dir: Path) -> None:
+    result = run([kroman, "안녕하세요"], cwd=work_dir, capture_output=True)
+    output = result.stdout.strip()
+    if output != "annyeonghaseyo":
+        raise AssertionError(f"Expected kroman to output 'annyeonghaseyo', got {output!r}")
+
+
+def main() -> int:
+    with tempfile.TemporaryDirectory(prefix="kroman-wheel-") as temp_dir:
+        temp_path = Path(temp_dir)
+        dist_dir = temp_path / "dist"
+        venv_dir = temp_path / "venv"
+
+        wheel_path = build_wheel(dist_dir)
+        validate_wheel_contents(wheel_path)
+
+        run([sys.executable, "-m", "venv", venv_dir], cwd=temp_path)
+        python = venv_path(venv_dir, "python")
+        kroman = venv_path(venv_dir, "kroman")
+
+        run([python, "-m", "pip", "install", wheel_path], cwd=temp_path)
+        validate_installed_metadata(python, temp_path)
+        validate_console_script(kroman, temp_path)
+
+        print(f"Validated {wheel_path.name}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/validate_wheel_metadata.py
+++ b/scripts/validate_wheel_metadata.py
@@ -47,17 +47,23 @@ def build_wheel(dist_dir: Path) -> Path:
 
 
 def validate_wheel_contents(wheel_path: Path) -> None:
-    blocked_prefixes = (".github/", "build/", "dist/", "docs/", "scripts/", "tests/")
     with zipfile.ZipFile(wheel_path) as wheel:
         names = wheel.namelist()
 
-    package_files = [name for name in names if name.startswith(f"{DIST_NAME}/")]
-    if not package_files:
+    dist_info_prefixes = [name for name in names if name.startswith(f"{DIST_NAME}-") and ".dist-info/" in name]
+    dist_info_roots = {name.split(".dist-info/", maxsplit=1)[0] + ".dist-info/" for name in dist_info_prefixes}
+    if len(dist_info_roots) != 1:
+        raise AssertionError(f"Expected exactly one {DIST_NAME} .dist-info tree, found: {sorted(dist_info_roots)}")
+
+    dist_info_root = dist_info_roots.pop()
+    allowed_prefixes = (f"{DIST_NAME}/", dist_info_root)
+
+    if not any(name.startswith(f"{DIST_NAME}/") for name in names):
         raise AssertionError(f"Wheel does not contain the {DIST_NAME} package")
 
-    unexpected = sorted(name for name in names if name.startswith(blocked_prefixes))
+    unexpected = sorted(name for name in names if not name.startswith(allowed_prefixes))
     if unexpected:
-        raise AssertionError(f"Wheel contains non-package project files: {unexpected}")
+        raise AssertionError(f"Wheel contains unexpected top-level files: {unexpected}")
 
 
 def validate_installed_metadata(python: Path, work_dir: Path) -> None:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,0 @@
-[metadata]
-description_file = README.md

--- a/setup.py
+++ b/setup.py
@@ -1,37 +1,3 @@
 from setuptools import setup
 
-setup(
-  name = 'korean_romanizer',
-  packages = ['korean_romanizer'],
-  use_scm_version=True,
-  license='GPL-3.0-or-later',
-  description = 'A Python library for Korean romanization',
-  author = 'Ilkyu Ju',
-  author_email = 'ju.ilkyu@gmail.com',
-  url = 'https://github.com/osori/korean-romanizer',
-  keywords = ['Korean', 'Romanization', 'Transliteration'],
-  classifiers=[
-    'Development Status :: 3 - Alpha',
-    'Intended Audience :: Developers',
-    'Topic :: Software Development :: Libraries :: Python Modules',
-    'Programming Language :: Python :: 3',
-    'Programming Language :: Python :: 3.4',
-    'Programming Language :: Python :: 3.5',
-    'Programming Language :: Python :: 3.6',
-  ],
-  entry_points={
-    'console_scripts': [
-      'kroman=korean_romanizer.cli:main',
-    ],
-  },
-  extras_require={
-    'dev': [
-      'build>=1.2',
-      'flake8>=7.0',
-      'mypy>=1.10',
-      'pytest>=8.0',
-      'pytest-cov>=5.0',
-      'ruff>=0.6',
-    ],
-  },
-)
+setup()


### PR DESCRIPTION
## Summary

- Move static package metadata from `setup.py` into PEP 621 `[project]` metadata in `pyproject.toml`.
- Keep Git-tag-derived versions through `setuptools-scm` with `dynamic = ["version"]`.
- Keep package inclusion explicit with `[tool.setuptools] packages = ["korean_romanizer"]` and retain `setup.py` as a minimal compatibility shim.
- Move the `dev` extra and `kroman` console entry point into `pyproject.toml`, remove unused `setup.cfg`, and correct README release wording to match the current published-release trigger.
- Add `scripts/validate_wheel_metadata.py` to build/install a wheel in a temporary venv and validate metadata, package contents, import behavior, `romanize()`, and `kroman`.
- Run the wheel metadata validator in the quality-gates workflow.

## Metadata Notes

Before:
- Static metadata lived in `setup.py`.
- `setup.cfg` only supplied the obsolete README metadata hint.
- Python classifiers advertised 3.4, 3.5, and 3.6.
- No explicit `Requires-Python` metadata was emitted.
- `dev` extra and `kroman` entry point were declared in `setup.py`.

After:
- PEP 621 metadata lives in `pyproject.toml` with `name = "korean_romanizer"`, `readme = "README.md"`, `requires-python = ">=3.10"`, SPDX license expression `GPL-3.0-or-later`, author, keywords, project URLs, and classifiers.
- Python classifiers now match CI: 3.10, 3.11, 3.12, and 3.13.
- `dev` is under `[project.optional-dependencies]`.
- `kroman = "korean_romanizer.cli:main"` is under `[project.scripts]`.
- Build metadata emits `Name: korean_romanizer`, `Requires-Python: >=3.10`, `License-Expression: GPL-3.0-or-later`, `Provides-Extra: dev`, and the `kroman` console entry point.
- The built wheel is validated by allowlist: only `korean_romanizer/` and the matching `.dist-info/` tree are allowed.
- The build backend now requires `setuptools>=77.0.3` for the current PEP 639 metadata path.

## Review Follow-Up

Addressed the non-blocking review notes from `pullrequestreview-4532236853`:
- Added `python scripts/validate_wheel_metadata.py` to the quality-gates job after `python -m build`.
- Changed `validate_wheel_contents()` from a blocklist to an allowlist for `korean_romanizer/` plus the distribution `.dist-info/` tree.
- Tightened the setuptools lower bound from `>=77` to `>=77.0.3`.

## Validation

Initial validation:
- `python3 -m pytest`: 153 passed, 1 skipped.
- `python3 -m pytest --cov=korean_romanizer`: 153 passed, 1 skipped, total coverage 90%.
- `ruff check .`: direct console script was unavailable on this Windows PATH; reran equivalent `python3 -m ruff check .`: passed.
- `mypy korean_romanizer`: direct console script was unavailable on this Windows PATH; reran equivalent `python3 -m mypy korean_romanizer`: passed.
- `python3 -m build`: passed; built sdist and wheel.
- `python3 scripts\validate_wheel_metadata.py`: passed.
- Clean temporary venv install from the built `dist/` wheel: `import korean_romanizer`, `romanize("안녕하세요") -> annyeonghaseyo`, and installed `kroman 안녕하세요 -> annyeonghaseyo` all passed.

Follow-up validation after addressing review feedback:
- `python3 -m pytest`: 153 passed, 1 skipped.
- `python3 -m ruff check .`: passed.
- `python3 -m mypy korean_romanizer`: passed.
- `python3 -m build`: passed.
- `python3 scripts\validate_wheel_metadata.py`: passed.

No runtime source, CLI behavior, or romanization-rule changes are included.