### PR TITLE
Extract representative-final pronunciation helper

### DIFF
--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -193,6 +193,31 @@ def _find_rieul_assimilation_preserved_boundaries(text):
     return boundaries
 
 
+def _apply_representative_final(
+    syllable,
+    *,
+    is_last_syllable,
+    final_is_before_consonant,
+):
+    # 1. 받침 ‘ㄲ, ㅋ’, ‘ㅅ, ㅆ, ㅈ, ㅊ, ㅌ’, ‘ㅍ’은 어말 또는 자음 앞에서 각각 대표음 [ㄱ, ㄷ, ㅂ]으로 발음한다.
+    # 2. 겹받침 ‘ㄳ’, ‘ㄵ’, ‘ㄼ, ㄽ, ㄾ’, ‘ㅄ’은 어말 또는 자음 앞에서 각각 [ㄱ, ㄴ, ㄹ, ㅂ]으로 발음한다.
+    # 3. 겹받침 ‘ㄺ, ㄻ, ㄿ’은 어말 또는 자음 앞에서 각각 [ㄱ, ㅁ, ㅂ]으로 발음한다.
+    # <-> 단, 국어의 로마자 표기법 규정에 의해 된소리되기는 표기에 반영하지 않으므로 제외.
+    if is_last_syllable or final_is_before_consonant:
+        if (syllable.final in ['ᆩ', 'ᆿ', 'ᆪ', 'ᆰ']):
+            syllable.final = 'ᆨ'
+        elif (syllable.final in ['ᆺ', 'ᆻ', 'ᆽ', 'ᆾ', 'ᇀ']):
+            syllable.final = 'ᆮ'
+        elif (syllable.final in ['ᇁ', 'ᆹ', 'ᆵ']):
+            syllable.final = 'ᆸ'
+        elif (syllable.final in ['ᆬ']):
+            syllable.final = 'ᆫ'
+        elif (syllable.final in ['ᆲ', 'ᆳ', 'ᆴ']):
+            syllable.final = 'ᆯ'
+        elif (syllable.final in ['ᆱ']):
+            syllable.final = 'ᆷ'
+
+
 def _apply_palatalization(syllable, next_syllable):
     if next_syllable.medial != MEDIAL_I:
         return
@@ -248,23 +273,11 @@ class Pronouncer(object):
 
             is_last_syllable = syllable.final and next_syllable is None
 
-            # 1. 받침 ‘ㄲ, ㅋ’, ‘ㅅ, ㅆ, ㅈ, ㅊ, ㅌ’, ‘ㅍ’은 어말 또는 자음 앞에서 각각 대표음 [ㄱ, ㄷ, ㅂ]으로 발음한다.
-            # 2. 겹받침 ‘ㄳ’, ‘ㄵ’, ‘ㄼ, ㄽ, ㄾ’, ‘ㅄ’은 어말 또는 자음 앞에서 각각 [ㄱ, ㄴ, ㄹ, ㅂ]으로 발음한다.
-            # 3. 겹받침 ‘ㄺ, ㄻ, ㄿ’은 어말 또는 자음 앞에서 각각 [ㄱ, ㅁ, ㅂ]으로 발음한다.
-            # <-> 단, 국어의 로마자 표기법 규정에 의해 된소리되기는 표기에 반영하지 않으므로 제외.
-            if is_last_syllable or final_is_before_C:
-                if (syllable.final in ['ᆩ', 'ᆿ', 'ᆪ', 'ᆰ']):
-                    syllable.final = 'ᆨ'
-                elif (syllable.final in ['ᆺ', 'ᆻ', 'ᆽ', 'ᆾ', 'ᇀ']):
-                    syllable.final = 'ᆮ'
-                elif (syllable.final in ['ᇁ', 'ᆹ', 'ᆵ']):
-                    syllable.final = 'ᆸ'
-                elif (syllable.final in ['ᆬ']):
-                    syllable.final = 'ᆫ'
-                elif (syllable.final in ['ᆲ', 'ᆳ', 'ᆴ']):
-                    syllable.final = 'ᆯ'
-                elif (syllable.final in ['ᆱ']):
-                    syllable.final = 'ᆷ'
+            _apply_representative_final(
+                syllable,
+                is_last_syllable=is_last_syllable,
+                final_is_before_consonant=final_is_before_C,
+            )
 
             # 4. 받침 ‘ㅎ’의 발음은 다음과 같다.
             if syllable.final in ['ᇂ', 'ᆭ', 'ᆶ']:

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -82,6 +82,30 @@ def test_pronouncer_current_behavior(text, expected):
 
 
 @pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("부엌", "부억"),
+        ("옷", "옫"),
+        ("앞", "압"),
+        ("넋", "넉"),
+        ("앉", "안"),
+        ("핥", "할"),
+        ("삶", "삼"),
+    ],
+)
+def test_representative_final_reduction_at_word_end_current_behavior(text, expected):
+    assert Pronouncer(text).pronounced == expected
+
+
+def test_representative_final_reduction_before_consonant_current_behavior():
+    assert Pronouncer("부엌문").pronounced == "부억문"
+
+
+def test_representative_final_preserves_vowel_linking_current_behavior():
+    assert Pronouncer("부엌에").pronounced == "부어케"
+
+
+@pytest.mark.parametrize(
     ("char", "expected"),
     [
         ("각", ("ᄀ", "ㅏ", "ᆨ", "각")),


### PR DESCRIPTION
## Summary

This is a behavior-neutral extraction.

- Extracted the existing Rules 1-3 representative-final reduction block from `Pronouncer.final_substitute()` into the private module-level `_apply_representative_final()` helper.
- Kept the call at the same point in `final_substitute()`, before the ㅎ, aspiration, palatalization, linking, and liquid/nasal rule handling.
- Added focused characterization tests for current representative-final behavior at word end, before a consonant, and before a vowel where linking remains unchanged.

## Validation

- `python3 -m pytest`
- `python3 -m pytest --cov=korean_romanizer`
- `python3 -m ruff check .`
- `python3 -m mypy korean_romanizer`
- `python3 -m build`
- `python3 scripts/validate_wheel_metadata.py`