### PR TITLE
Extract final-h pronunciation helper

### DIFF
--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -233,6 +233,49 @@ def _apply_palatalization(syllable, next_syllable):
         syllable.final, next_syllable.initial = replacement
 
 
+def _apply_final_h_rules(syllable, next_syllable):
+    # 4. 받침 ‘ㅎ’의 발음은 다음과 같다.
+    if syllable.final in ['ᇂ', 'ᆭ', 'ᆶ']:
+        without_ㅎ = {
+            'ᆭ': 'ᆫ',
+            'ᆶ': 'ᆯ',
+            'ᇂ': None
+        }
+
+        if next_syllable:
+            # ‘ㅎ(ㄶ, ㅀ)’ 뒤에 ‘ㄱ, ㄷ, ㅈ’이 결합되는 경우에는, 뒤 음절 첫소리와 합쳐서 [ㅋ, ㅌ, ㅊ]으로 발음한다.
+            # ‘ㅎ(ㄶ, ㅀ)’ 뒤에 ‘ㅅ’이 결합되는 경우에는, ‘ㅅ’을 [ㅆ]으로 발음한다.
+            if next_syllable.initial in ['ᄀ', 'ᄃ', 'ᄌ', 'ᄉ']:
+                change_to = {'ᄀ': 'ᄏ', 'ᄃ': 'ᄐ', 'ᄌ': 'ᄎ', 'ᄉ': 'ᄊ'}
+                syllable.final = without_ㅎ[syllable.final]
+                next_syllable.initial = change_to[next_syllable.initial]
+            # 3. ‘ㅎ’ 뒤에 ‘ㄴ’이 결합되는 경우에는, [ㄴ]으로 발음한다.
+            elif next_syllable.initial in ['ᄂ']:
+                # TODO: [붙임] ‘ㄶ, ㅀ’ 뒤에 ‘ㄴ’이 결합되는 경우에는, ‘ㅎ’을 발음하지 않는다.
+                if (syllable.final in ['ᆭ', 'ᆶ']):
+                    syllable.final = without_ㅎ[syllable.final]
+                else:
+                    syllable.final = 'ᆫ'
+            # 4. ‘ㅎ(ㄶ, ㅀ)’ 뒤에 모음으로 시작된 어미나 접미사가 결합되는 경우에는,
+            # ‘ㅎ’을 발음하지 않는다.
+            elif next_syllable.initial == NULL_CONSONANT:
+                if (syllable.final in ['ᆭ', 'ᆶ']):
+                    if syllable.final == 'ᆭ':
+                        syllable.final = 'ᆫ'
+                    elif syllable.final == 'ᆶ':
+                        syllable.final = 'ᆯ'
+                else:
+                    syllable.final = None
+            elif next_syllable.initial == 'ᄅ':
+                if (syllable.final == 'ᆶ'):
+                    syllable.final = 'ᆯ'
+            else:
+                if (syllable.final == 'ᇂ'):
+                    syllable.final = None
+        else:
+            syllable.final = without_ㅎ[syllable.final]
+
+
 def _apply_h_aspiration(syllable, next_syllable):
     aspirated_initial = ASPIRATED_BEFORE_H_BY_FINAL.get(syllable.final)
     if aspirated_initial and next_syllable.initial == INITIAL_H:
@@ -279,47 +322,8 @@ class Pronouncer(object):
                 final_is_before_consonant=final_is_before_C,
             )
 
-            # 4. 받침 ‘ㅎ’의 발음은 다음과 같다.
-            if syllable.final in ['ᇂ', 'ᆭ', 'ᆶ']:
-                without_ㅎ = {
-                    'ᆭ': 'ᆫ',
-                    'ᆶ': 'ᆯ',
-                    'ᇂ': None
-                }
+            _apply_final_h_rules(syllable, next_syllable)
 
-                if next_syllable:
-                    # ‘ㅎ(ㄶ, ㅀ)’ 뒤에 ‘ㄱ, ㄷ, ㅈ’이 결합되는 경우에는, 뒤 음절 첫소리와 합쳐서 [ㅋ, ㅌ, ㅊ]으로 발음한다.
-                    # ‘ㅎ(ㄶ, ㅀ)’ 뒤에 ‘ㅅ’이 결합되는 경우에는, ‘ㅅ’을 [ㅆ]으로 발음한다.
-                    if next_syllable.initial in ['ᄀ', 'ᄃ', 'ᄌ', 'ᄉ']:
-                        change_to = {'ᄀ': 'ᄏ', 'ᄃ': 'ᄐ', 'ᄌ': 'ᄎ', 'ᄉ': 'ᄊ'}
-                        syllable.final = without_ㅎ[syllable.final]
-                        next_syllable.initial = change_to[next_syllable.initial]
-                    # 3. ‘ㅎ’ 뒤에 ‘ㄴ’이 결합되는 경우에는, [ㄴ]으로 발음한다.
-                    elif next_syllable.initial in ['ᄂ']:
-                        # TODO: [붙임] ‘ㄶ, ㅀ’ 뒤에 ‘ㄴ’이 결합되는 경우에는, ‘ㅎ’을 발음하지 않는다.
-                        if (syllable.final in ['ᆭ', 'ᆶ']):
-                            syllable.final = without_ㅎ[syllable.final]
-                        else:
-                            syllable.final = 'ᆫ'
-                    # 4. ‘ㅎ(ㄶ, ㅀ)’ 뒤에 모음으로 시작된 어미나 접미사가 결합되는 경우에는,
-                    # ‘ㅎ’을 발음하지 않는다.
-                    elif next_syllable.initial == NULL_CONSONANT:
-                        if (syllable.final in ['ᆭ', 'ᆶ']):
-                            if syllable.final == 'ᆭ':
-                                syllable.final = 'ᆫ'
-                            elif syllable.final == 'ᆶ':
-                                syllable.final = 'ᆯ'
-                        else:
-                            syllable.final = None
-                    elif next_syllable.initial == 'ᄅ':
-                        if (syllable.final == 'ᆶ'):
-                            syllable.final = 'ᆯ'
-                    else:
-                        if (syllable.final == 'ᇂ'):
-                            syllable.final = None
-                else:
-                    syllable.final = without_ㅎ[syllable.final]
-                        
             # RR transcribes source-backed ㅎ aspiration, e.g. 잡혀[자펴],
             # while preserving noun examples such as 묵호 and 집현전.
             if next_syllable and idx in self._h_aspiration_boundaries:

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -69,8 +69,6 @@ def test_final_consonant_rules_current_behavior(text, expected):
     ("text", "expected"),
     [
         ("좋습니다", "조씁니다"),
-        ("낳은", "나은"),
-        ("싫어", "시러"),
         ("넋없다", "넉섭다"),
         ("값있는", "갑싣는"),
         ("외곬으로", "외골쓰로"),
@@ -78,6 +76,29 @@ def test_final_consonant_rules_current_behavior(text, expected):
     ],
 )
 def test_pronouncer_current_behavior(text, expected):
+    assert Pronouncer(text).pronounced == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
+        ("놓고", "노코"),
+        ("놓다", "노타"),
+        ("낳지", "나치"),
+        ("많소", "만쏘"),
+        ("좋니", "존니"),
+        ("닿는", "단는"),
+        ("놓아", "노아"),
+        ("낳은", "나은"),
+        ("싫어", "시러"),
+        ("뚫리다", "뚤리다"),
+        ("좋", "조"),
+        ("않", "안"),
+        ("앓", "알"),
+    ],
+)
+def test_final_h_rules_current_behavior(text, expected):
+    # Characterize preserved final-ㅎ pronunciation behavior, not RR claims.
     assert Pronouncer(text).pronounced == expected
 
 


### PR DESCRIPTION
## Summary

- Extract the existing coda ㅎ / ㄶ / ㅀ rule block from `Pronouncer.final_substitute()` into private helper `_apply_final_h_rules(...)`.
- Keep the helper call at the same point in the pronunciation flow: after representative-final handling and before `_apply_h_aspiration()`, palatalization, linking, and liquid/nasal assimilation.
- Add focused Pronouncer-level characterization coverage for the preserved final-ㅎ branches.

## Behavior

This is a behavior-neutral extraction. It does not change public APIs, constants, import paths, in-place mutation, or intended pronunciation/romanization results.

## Validation

- `python3 -m pytest`
- `python3 -m pytest --cov=korean_romanizer`
- `python3 -m ruff check .`
- `python3 -m mypy korean_romanizer`
- `python3 -m build`
- `python3 scripts/validate_wheel_metadata.py`