### PR TITLE
Extract double-final vowel-linking helper

### DIFF
--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -283,6 +283,16 @@ def _apply_h_aspiration(syllable, next_syllable):
         next_syllable.initial = aspirated_initial
 
 
+def _apply_double_final_linking(syllable, next_syllable):
+    # 6. 겹받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
+    # 뒤엣것만을 뒤 음절 첫소리로 옮겨 발음한다.(이 경우, ‘ㅅ’은 된소리로 발음함.)
+    if syllable.final in double_consonant_final and next_syllable.initial == NULL_CONSONANT:
+        double_consonant = double_consonant_final[syllable.final]
+        syllable.final = double_consonant[0]
+        next_syllable.initial = next_syllable.final_to_initial(
+            double_consonant[1])
+
+
 class Pronouncer(object):
     """Apply Korean pronunciation substitutions before romanization."""
 
@@ -334,13 +344,7 @@ class Pronouncer(object):
             if next_syllable and idx in self._palatalization_boundaries:
                 _apply_palatalization(syllable, next_syllable)
 
-            # 6. 겹받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
-            # 뒤엣것만을 뒤 음절 첫소리로 옮겨 발음한다.(이 경우, ‘ㅅ’은 된소리로 발음함.)
-            if syllable.final in double_consonant_final and next_syllable.initial == NULL_CONSONANT:
-                double_consonant = double_consonant_final[syllable.final]
-                syllable.final = double_consonant[0]
-                next_syllable.initial = next_syllable.final_to_initial(
-                    double_consonant[1])
+            _apply_double_final_linking(syllable, next_syllable)
 
             # Revised Romanization follows pronounced forms for adjacent liquids
             # and nasals, e.g. 종로[종노], 왕십리[왕심니], 신라[실라],

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -82,6 +82,25 @@ def test_pronouncer_current_behavior(text, expected):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
+        ("없어", "업서"),
+        ("앉아", "안자"),
+        ("닭이", "달기"),
+        ("밟아", "발바"),
+        ("닮아", "달마"),
+        ("삯을", "삭슬"),
+        ("읊어", "을퍼"),
+        ("곬이", "골씨"),
+        ("훑어", "훌터"),
+    ],
+)
+def test_double_final_vowel_linking_current_behavior(text, expected):
+    # Preserved behavior fixtures, not new RR correctness claims.
+    assert Pronouncer(text).pronounced == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
         ("놓고", "노코"),
         ("놓다", "노타"),
         ("낳지", "나치"),


### PR DESCRIPTION
## Summary

- Extracts the existing Rule 6 double-final vowel-linking block from `Pronouncer.final_substitute()` into the private module-level `_apply_double_final_linking()` helper.
- Calls the helper at the same point in the rule order, after final-ㅎ handling, guarded ㅎ aspiration, and palatalization, and before liquid/nasal assimilation and ordinary single-final linking.
- Adds focused `Pronouncer` characterization fixtures for the preserved double-final vowel-linking behavior.

This is behavior-neutral and does not change public APIs, constants, imports, or romanization behavior.

## Validation

- `python3 -m pytest`
- `python3 -m pytest --cov=korean_romanizer`
- `python3 -m ruff check .`
- `python3 -m mypy korean_romanizer`
- `python3 -m build`
- `python3 scripts/validate_wheel_metadata.py`