### PR TITLE
Add kroman version option

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ kroman 안녕하세요
 # annyeonghaseyo
 ```
 
+Check the installed command version:
+
+```bash
+kroman --version
+# kroman <installed-version>
+```
+
 Wildcard imports now follow the explicit public API in `__all__`:
 
 ```python

--- a/korean_romanizer/cli.py
+++ b/korean_romanizer/cli.py
@@ -1,15 +1,32 @@
 import argparse
+from importlib import metadata
 
 from korean_romanizer import romanize
+
+
+_DISTRIBUTION_NAME = "korean_romanizer"
+
+
+class _VersionAction(argparse.Action):
+    def __call__(self, parser, namespace, values, option_string=None):
+        print(f"kroman {metadata.version(_DISTRIBUTION_NAME)}")
+        parser.exit()
+
 
 def main():
     """Run the kroman command-line interface."""
     parser = argparse.ArgumentParser(description='Romanize Korean text.')
+    parser.add_argument(
+        '--version',
+        action=_VersionAction,
+        nargs=0,
+        help="show program's version number and exit",
+    )
     parser.add_argument('text', nargs='+', help='The Korean text to be romanized.')
     args = parser.parse_args()
-    
+
     text_to_romanize = " ".join(args.text)
-    
+
     result = romanize(text_to_romanize)
     print(result)
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,8 @@ import os
 import shutil
 import subprocess
 import sys
+import sysconfig
+from importlib import metadata
 from pathlib import Path
 
 import pytest
@@ -9,6 +11,7 @@ from korean_romanizer.romanizer import Romanizer
 
 
 UTF8_ENV = {**os.environ, "PYTHONIOENCODING": "UTF-8"}
+DIST_NAME = "korean_romanizer"
 
 
 def _run_cli(args, *, input=None):
@@ -23,6 +26,30 @@ def _run_cli(args, *, input=None):
         env=UTF8_ENV,
         timeout=10,
     )
+
+
+def _find_kroman():
+    exe = shutil.which("kroman")
+    if exe:
+        return exe
+    script_dirs = {Path(sys.executable).parent, Path(sysconfig.get_path("scripts"))}
+    user_scheme = f"{os.name}_user"
+    if user_scheme in sysconfig.get_scheme_names():
+        script_dirs.add(Path(sysconfig.get_path("scripts", scheme=user_scheme)))
+    for script_dir in script_dirs:
+        for script_name in ("kroman", "kroman.exe"):
+            candidate = script_dir / script_name
+            if candidate.exists():
+                return str(candidate)
+    for script_name in ("kroman", "kroman.exe"):
+        candidate = Path(sys.executable).with_name(script_name)
+        if candidate.exists():
+            return str(candidate)
+    return None
+
+
+def _expected_version_line():
+    return f"kroman {metadata.version(DIST_NAME)}"
 
 
 @pytest.mark.parametrize(
@@ -43,11 +70,36 @@ def test_cli_matches_library(text):
     assert proc.stdout.strip() == expected
 
 
+def test_console_script_version():
+    exe = _find_kroman()
+    if not exe:
+        pytest.skip("kroman console script not installed")
+    proc = subprocess.run(
+        [exe, "--version"],
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        check=False,
+        env=UTF8_ENV,
+        timeout=10,
+    )
+    assert proc.returncode == 0
+    assert proc.stderr == ""
+    assert proc.stdout.strip() == _expected_version_line()
+
+
 def test_cli_help():
     proc = _run_cli(["-h"])
     assert proc.returncode == 0
     assert proc.stderr == ""
     assert "usage" in proc.stdout.lower()
+
+
+def test_cli_version():
+    proc = _run_cli(["--version"])
+    assert proc.returncode == 0
+    assert proc.stderr == ""
+    assert proc.stdout.strip() == _expected_version_line()
 
 
 @pytest.mark.parametrize("stdin", [None, "안녕하세요\n"])
@@ -68,15 +120,7 @@ def test_cli_long_input():
 
 
 def test_console_script_smoke():
-    exe = shutil.which("kroman")
-    if not exe:
-        candidate = Path(sys.executable).with_name("kroman")
-        if candidate.exists():
-            exe = str(candidate)
-    if not exe:
-        candidate = Path(sys.executable).with_name("kroman.exe")
-        if candidate.exists():
-            exe = str(candidate)
+    exe = _find_kroman()
     if not exe:
         pytest.skip("kroman console script not installed")
     proc = subprocess.run(


### PR DESCRIPTION
## Summary

- Add `kroman --version` using `importlib.metadata.version("korean_romanizer")`.
- Preserve existing positional CLI behavior while supporting both `python -m korean_romanizer.cli --version` and installed `kroman --version`.
- Add focused CLI coverage and a README example.

## Validation

- `python -m pytest`
- `python -m pytest --cov=korean_romanizer`
- `python -m ruff check .`
- `python -m mypy korean_romanizer`
- `python -m build`
- `python scripts\validate_wheel_metadata.py`