### PR TITLE
Extract single-final vowel-linking helper

### DIFF
--- a/korean_romanizer/pronouncer.py
+++ b/korean_romanizer/pronouncer.py
@@ -321,6 +321,22 @@ def _apply_liquid_nasal_assimilation(
         next_syllable.initial = INITIAL_RIEUL
 
 
+def _apply_single_final_linking(
+    syllable,
+    next_syllable,
+    *,
+    final_is_before_vowel,
+):
+    # 5. 홑받침이나 쌍받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
+    # 제 음가대로 뒤 음절 첫소리로 옮겨 발음한다.
+    if next_syllable and final_is_before_vowel:
+        # do nothing if final is ᆼ or null
+        if (next_syllable.initial == NULL_CONSONANT and syllable.final not in ["ᆼ", None]):
+            next_syllable.initial = next_syllable.final_to_initial(
+                syllable.final)
+            syllable.final = None
+
+
 class Pronouncer(object):
     """Apply Korean pronunciation substitutions before romanization."""
 
@@ -385,13 +401,10 @@ class Pronouncer(object):
                     preserve_rieul_boundary=idx in self._rieul_assimilation_preserved_boundaries,
                 )
 
-            # 5. 홑받침이나 쌍받침이 모음으로 시작된 조사나 어미, 접미사와 결합되는 경우에는,
-            # 제 음가대로 뒤 음절 첫소리로 옮겨 발음한다.
-            if next_syllable and final_is_before_V:
-                # do nothing if final is ᆼ or null
-                if (next_syllable.initial == NULL_CONSONANT and syllable.final not in ["ᆼ", None]):
-                    next_syllable.initial = next_syllable.final_to_initial(
-                        syllable.final)
-                    syllable.final = None
+            _apply_single_final_linking(
+                syllable,
+                next_syllable,
+                final_is_before_vowel=final_is_before_V,
+            )
 
         return self._syllables

--- a/tests/test_characterization.py
+++ b/tests/test_characterization.py
@@ -101,6 +101,21 @@ def test_double_final_vowel_linking_current_behavior(text, expected):
 @pytest.mark.parametrize(
     ("text", "expected"),
     [
+        ("각이", "가기"),
+        ("옷을", "오슬"),
+        ("낮아", "나자"),
+        ("꽃이", "꼬치"),
+        ("앞에", "아페"),
+        ("강아지", "강아지"),
+    ],
+)
+def test_single_final_vowel_linking_current_behavior(text, expected):
+    assert Pronouncer(text).pronounced == expected
+
+
+@pytest.mark.parametrize(
+    ("text", "expected"),
+    [
         ("놓고", "노코"),
         ("놓다", "노타"),
         ("낳지", "나치"),


### PR DESCRIPTION
## Summary

- Extract the existing ordinary single-final vowel-linking Rule 5 block from `Pronouncer.final_substitute()` into a private module-level `_apply_single_final_linking()` helper.
- Keep the helper call in the same rule position after double-final linking and liquid/nasal assimilation.
- Add Pronouncer characterization coverage for current single-final vowel-linking behavior and the `ᆼ` exclusion guard.

This is a behavior-neutral extraction with no public API, pronunciation, or romanization output changes intended.

## Validation

- `python3 -m pytest`
- `python3 -m pytest --cov=korean_romanizer`
- `python3 -m ruff check .`
- `python3 -m mypy korean_romanizer`
- `python3 -m build`
- `python3 scripts/validate_wheel_metadata.py`