### PR TITLE
Make Syllable repr non-mutating

### DIFF
--- a/korean_romanizer/syllable.py
+++ b/korean_romanizer/syllable.py
@@ -12,6 +12,20 @@ unicode_medial_offset = 28
 unicode_compatible_consonants = ['ㄱ', 'ㄲ', 'ㄴ', 'ㄷ', 'ㄸ', 'ㄹ', 'ㅁ', 'ㅂ', 'ㅃ', 'ㅅ', 'ㅆ', 'ㅇ', 'ㅈ', 'ㅉ', 'ㅊ', 'ㅋ', 'ㅌ', 'ㅍ', 'ㅎ']
 unicode_compatible_finals =     ['ᆨ', 'ᆩ', 'ᆫ', 'ᆮ', '_', 'ᆯ', 'ᆷ', 'ᆸ', '_', 'ᆺ', 'ᆻ', 'ᆼ', 'ᆽ', '_', 'ᆾ', 'ᆿ', 'ᇀ', 'ᇁ', 'ᇂ']
 
+
+def _construct_syllable_char(char, initial, medial, final):
+    if 0xAC00 <= ord(char) <= 0xD7A3:
+        initial = ord(initial) - 4352
+        medial = unicode_medial.index(medial)
+        if final is None:
+            final = 0
+        else:
+            final = unicode_final.index(final)
+        return chr((((initial * unicode_initial_offset) + (medial * unicode_medial_offset)) + final) + unicode_offset)
+
+    return char
+
+
 class Syllable(object):
     """Represent a Hangul syllable decomposed into jamo components."""
 
@@ -40,17 +54,7 @@ class Syllable(object):
         return self.is_hangul(char), [initial, medial, final]
     
     def construct_syllable(self, initial, medial, final):
-        if self.is_hangul(self.char):
-            initial = ord(initial) - 4352
-            medial = unicode_medial.index(medial)
-            if final is None:
-                final = 0
-            else:
-                final = unicode_final.index(final)
-            constructed = chr((((initial * unicode_initial_offset) + (medial * unicode_medial_offset)) + final) + unicode_offset)
-        else:
-            constructed = self.char
-            
+        constructed = _construct_syllable_char(self.char, initial, medial, final)
         self.char = constructed
         return constructed
     
@@ -62,8 +66,7 @@ class Syllable(object):
         return unicode_initial[idx]
     
     def __repr__(self):
-        self.construct_syllable(self.initial, self.medial, self.final)
-        return self.char
+        return _construct_syllable_char(self.char, self.initial, self.medial, self.final)
     
     def __str__(self):
         self.char = self.construct_syllable(self.initial, self.medial, self.final)

--- a/tests/test_syllable_characterization.py
+++ b/tests/test_syllable_characterization.py
@@ -1,18 +1,16 @@
 from korean_romanizer.syllable import Syllable
 
 
-# Characterization tests for existing compatibility behavior, not desired future
-# semantics. These lock down current reconstruction side effects before changing
-# Syllable mutation behavior.
+# Characterization tests for Syllable reconstruction side effects.
 
 
-def test_repr_reconstructs_and_mutates_char_when_final_is_removed_current_behavior():
+def test_repr_reconstructs_without_mutating_char_when_final_is_removed():
     syllable = Syllable("각")
     syllable.final = None
 
     assert syllable.char == "각"
     assert repr(syllable) == "가"
-    assert syllable.char == "가"
+    assert syllable.char == "각"
 
 
 def test_str_reconstructs_and_mutates_char_when_final_is_removed_current_behavior():
@@ -32,7 +30,7 @@ def test_construct_syllable_returns_reconstructed_char_and_mutates_char_current_
     assert syllable.char == "가"
 
 
-def test_component_changes_are_used_for_reconstruction_current_behavior():
+def test_repr_uses_component_changes_without_mutating_char():
     syllable = Syllable("각")
     replacement = Syllable("동")
     syllable.initial = replacement.initial
@@ -40,18 +38,23 @@ def test_component_changes_are_used_for_reconstruction_current_behavior():
     syllable.final = replacement.final
 
     assert repr(syllable) == "동"
-    assert syllable.char == "동"
+    assert syllable.char == "각"
 
 
-def test_repeated_repr_and_str_calls_after_reconstruction_current_behavior():
-    syllable = Syllable("각")
-    syllable.final = None
+def test_repeated_repr_and_str_calls_show_only_str_mutates_char():
+    repr_syllable = Syllable("각")
+    repr_syllable.final = None
 
-    assert repr(syllable) == "가"
-    assert repr(syllable) == "가"
-    assert str(syllable) == "가"
-    assert str(syllable) == "가"
-    assert syllable.char == "가"
+    assert repr(repr_syllable) == "가"
+    assert repr(repr_syllable) == "가"
+    assert repr_syllable.char == "각"
+
+    str_syllable = Syllable("각")
+    str_syllable.final = None
+
+    assert str(str_syllable) == "가"
+    assert str(str_syllable) == "가"
+    assert str_syllable.char == "가"
 
 
 def test_non_hangul_repr_and_str_preserve_existing_char_current_behavior():


### PR DESCRIPTION
## Summary

- Added a pure `_construct_syllable_char(...)` helper for Hangul syllable reconstruction.
- Changed `Syllable.__repr__()` to return reconstructed text without assigning to `self.char`.
- Kept `str(syllable)` and `construct_syllable(...)` mutating behavior covered by characterization tests.

## Compatibility Note

This is an intentional low-level compatibility behavior change for `Syllable.__repr__` only. It makes `repr()` side-effect-free while preserving returned text and keeping `str()`/`construct_syllable()` behavior unchanged.

## Validation

- `python3 -m pytest`
- `python3 -m pytest --cov=korean_romanizer`
- `python3 -m ruff check .`
- `python3 -m mypy korean_romanizer`
- `python3 -m build`
- `python3 scripts/validate_wheel_metadata.py`