### PR TITLE
Document the kroman CLI input contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ kroman 안녕하세요
 # annyeonghaseyo
 ```
 
+`kroman` requires positional text and does not read stdin. Multiple arguments
+are joined with one space; whitespace inside each quoted argument is preserved.
+Output ends with a newline.
+
 Check the installed command version:
 
 ```bash

--- a/docs/modernization-plan.md
+++ b/docs/modernization-plan.md
@@ -1,8 +1,8 @@
 # Modernization Plan
 
-This plan is current through PR #58 on 2026-07-24 and includes the Stage 3
-inventory in this change. It replaces the earlier open-ended PR checklist
-with finite work stages leading to v1.0.0.
+This plan is current through PR #59 on 2026-07-24 and records the first Stage 4
+contract decision in this change. It replaces the earlier open-ended PR
+checklist with finite work stages leading to v1.0.0.
 
 The project will maintain a **bounded deterministic core**: every Python
 `str` input must produce a `str` without leaking an internal exception, while
@@ -34,7 +34,7 @@ rules remain Python module data rather than external datasets.
 
 ### Tests and Quality Gates
 
-The current suite collects 244 tests:
+The current suite collects 246 tests:
 
 - `tests/test_characterization.py` preserves mixed text, whitespace,
   compatibility jamo, and existing pronunciation behavior.
@@ -86,9 +86,9 @@ Compatibility surfaces remain supported until an explicit deprecation:
 - the four names exported by `korean_romanizer.__all__`
 
 Mixed non-Korean text, punctuation, and whitespace remain preserved by the
-library unless a focused change is documented and tested. The CLI's
-argument-joining behavior is separately subject to the Stage 4 contract
-decision.
+library unless a focused change is documented and tested. The CLI requires
+positional text, does not read stdin, joins arguments with one space, and
+preserves whitespace within each argument.
 
 Module-level tables, constants, and private helpers remain implementation
 details even when Python makes them importable. Stage 4 will define the
@@ -235,7 +235,7 @@ remains green. PR #57 met this criterion.
 
 ### Stage 3: Build a Bounded RR Inventory
 
-**Status:** Complete in this inventory refresh.
+**Status:** Complete in PR #59.
 
 Completed scope: `docs/rr-inventory.md` inventories every word- and name-level
 example on the
@@ -268,7 +268,7 @@ contract`.
 The only next behavior-change candidate is general nasal assimilation,
 represented by 백마[뱅마]. 학여울 and 알약 are documented limitations. Any
 behavior implementation must be a separate source-backed one-rule-family
-change. No runtime behavior or tests changed in this inventory refresh.
+change. PR #59 changed no runtime behavior or tests.
 
 **Exit criterion:** Met. Every example in the dated primary source snapshot
 has a source, category, current result, and explicit disposition. Strict
@@ -279,13 +279,18 @@ block release.
 
 ### Stage 4: Finish Contract Decisions
 
-**Status:** Next.
+**Status:** In progress; the CLI contract is complete in this change.
 
-Decide and document:
+Completed decision:
+
+- `kroman` requires positional text and does not read stdin. It joins positional
+  arguments with one space, preserves whitespace within each argument, and
+  writes a trailing newline.
+
+Remaining decisions:
 
 - whether Unicode normalization and modern decomposed-jamo handling are
   automatic, optional, or intentionally unchanged;
-- whether `kroman` accepts stdin and how positional whitespace is handled;
 - whether non-string input has an explicit `TypeError` contract or preserves
   current natural exceptions;
 - the supported lower-level compatibility surface, including `Pronouncer`,

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,10 +103,26 @@ def test_cli_version():
 
 
 @pytest.mark.parametrize("stdin", [None, "안녕하세요\n"])
-def test_cli_no_args_shows_usage(stdin):
+def test_cli_requires_positional_text_even_with_stdin(stdin):
     proc = _run_cli([], input=stdin)
-    assert proc.returncode != 0
-    assert "usage" in proc.stderr.lower()
+    assert proc.returncode == 2
+    assert proc.stdout == ""
+    assert proc.stderr.lower().startswith("usage:")
+    assert "arguments are required: text" in proc.stderr
+
+
+def test_cli_ignores_stdin_when_positional_text_is_present():
+    proc = _run_cli(["서울"], input="부산\n")
+    assert proc.returncode == 0
+    assert proc.stderr == ""
+    assert proc.stdout == "seoul\n"
+
+
+def test_cli_preserves_intra_argument_whitespace_and_joins_arguments():
+    proc = _run_cli([" 안녕\t", "  서울 "])
+    assert proc.returncode == 0
+    assert proc.stderr == ""
+    assert proc.stdout == " annyeong\t   seoul \n"
 
 
 def test_cli_long_input():


### PR DESCRIPTION
## Summary

- document the existing `kroman` positional-input, stdin, whitespace, and trailing-newline behavior
- add exact regressions for missing positional text, ignored stdin, and argument joining
- mark the CLI contract decision complete in Stage 4

## Impact

This intentionally preserves current CLI behavior. No runtime code or romanization behavior changes.

## Checks

- `python -m pytest` — 246 passed
- `python -m ruff check .`
- `python -m mypy korean_romanizer`
- independent review: no remaining findings